### PR TITLE
Consume rmq events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1095,6 +1095,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "config"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7328b20597b53c2454f0b1919720c25c7339051c02b72b7e05409e00b14132be"
+dependencies = [
+ "async-trait",
+ "convert_case 0.6.0",
+ "json5",
+ "lazy_static",
+ "nom",
+ "pathdiff",
+ "ron",
+ "rust-ini",
+ "serde",
+ "serde_json",
+ "toml 0.8.12",
+ "yaml-rust",
+]
+
+[[package]]
 name = "console"
 version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1114,10 +1134,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "cookie-factory"
@@ -1445,7 +1494,7 @@ version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
- "convert_case",
+ "convert_case 0.4.0",
  "proc-macro2",
  "quote",
  "rustc_version",
@@ -1518,6 +1567,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.60",
+]
+
+[[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
 ]
 
 [[package]]
@@ -2024,6 +2082,12 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+
+[[package]]
+name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
@@ -2365,6 +2429,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "json5"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "serde",
+]
+
+[[package]]
 name = "jsonrpc"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2524,6 +2599,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2952,6 +3033,7 @@ dependencies = [
  "ciborium",
  "clap",
  "colored",
+ "config",
  "criterion",
  "ctrlc",
  "dirs",
@@ -3026,6 +3108,16 @@ dependencies = [
  "bitcoin-private",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "ordered-multimap"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ed8acf08e98e744e5384c8bc63ceb0364e68a6854187221c18df61c4797690e"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.13.2",
 ]
 
 [[package]]
@@ -3124,6 +3216,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
+name = "pathdiff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
+
+[[package]]
 name = "pbkdf2"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3156,6 +3254,51 @@ name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "pest"
+version = "2.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "560131c633294438da9f7c4b08189194b20946c8274c6b9e38881a7874dc8ee8"
+dependencies = [
+ "memchr",
+ "thiserror",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26293c9193fbca7b1a3bf9b79dc1e388e927e6cacaa78b4a3ab705a1d3d41459"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ec22af7d3fb470a85dd2ca96b7c577a1eb4ef6f1683a9fe9a8c16e136c04687"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.60",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a240022f37c361ec1878d646fc5b7d7c4d28d5946e1a80ad5a7a4f4ca0bdcd"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha2",
+]
 
 [[package]]
 name = "pin-project"
@@ -3372,7 +3515,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
 dependencies = [
- "toml",
+ "toml 0.5.11",
 ]
 
 [[package]]
@@ -3653,6 +3796,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ron"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
+dependencies = [
+ "base64 0.21.7",
+ "bitflags 2.5.0",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
 name = "rsa"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3716,6 +3871,16 @@ checksum = "86f69089032567ffff4eada41c573fc43ff466c7db7c5688b2e7969584345581"
 dependencies = [
  "sha2",
  "walkdir",
+]
+
+[[package]]
+name = "rust-ini"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e2a3bcec1f113553ef1c88aae6c020a369d03d55b58de9869a0908930385091"
+dependencies = [
+ "cfg-if 1.0.0",
+ "ordered-multimap",
 ]
 
 [[package]]
@@ -4084,6 +4249,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
 dependencies = [
  "itoa",
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
+dependencies = [
  "serde",
 ]
 
@@ -4690,6 +4864,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4813,6 +4996,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9dd1545e8208b4a5af1aa9bbd0b4cf7e9ea08fabc5d0a5c67fcaafa17433aa3"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3328d4f68a705b2a4498da1d580585d39a6510f98318a2cec3018a7ec61ddef"
+dependencies = [
+ "indexmap 2.2.6",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
 name = "tower"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4906,6 +5123,12 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 
 [[package]]
 name = "unicase"
@@ -5364,6 +5587,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
 
 [[package]]
+name = "winnow"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14b9415ee827af173ebb3f15f9083df5a122eb93572ec28741fb153356ea2578"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "winreg"
 version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5417,6 +5649,15 @@ dependencies = [
  "rusticata-macros",
  "thiserror",
  "time",
+]
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+dependencies = [
+ "cfg-if 1.0.0",
+ "getrandom",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -51,6 +64,12 @@ checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
 dependencies = [
  "alloc-no-stdlib",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
 name = "amq-protocol"
@@ -286,11 +305,11 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07dbbf24db18d609b1462965249abdf49129ccad073ec257da372adc83259c60"
+checksum = "4e9eabd7a98fe442131a17c316bd9349c43695e49e730c3c8e12cfb5f4da2693"
 dependencies = [
- "brotli 4.0.0",
+ "brotli",
  "flate2",
  "futures-core",
  "memchr",
@@ -492,6 +511,15 @@ dependencies = [
  "strum",
  "thiserror",
  "utf-8",
+]
+
+[[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -763,6 +791,9 @@ name = "bitflags"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "block-buffer"
@@ -814,34 +845,13 @@ dependencies = [
 
 [[package]]
 name = "brotli"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "125740193d7fee5cc63ab9e16c2fdc4e07c74ba755cc53b327d6ea029e9fc569"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
- "brotli-decompressor 3.0.0",
-]
-
-[[package]]
-name = "brotli"
 version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19483b140a7ac7174d34b5a581b406c64f84da5409d3e09cf4fff604f9270e67"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
- "brotli-decompressor 4.0.0",
-]
-
-[[package]]
-name = "brotli-decompressor"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65622a320492e09b5e0ac436b14c54ff68199bac392d0e89a6832c4518eea525"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
+ "brotli-decompressor",
 ]
 
 [[package]]
@@ -1141,6 +1151,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69e6e4d7b33a94f0991c26729976b10ebde1d34c3ee82408fb536164fa10d636"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
 name = "crc32fast"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1200,6 +1225,15 @@ name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1440,6 +1474,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
  "subtle",
 ]
@@ -1492,6 +1527,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
 name = "dunce"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1502,6 +1543,9 @@ name = "either"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "encode_unicode"
@@ -1555,6 +1599,17 @@ checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if 1.0.0",
+ "home",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1636,6 +1691,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
 
 [[package]]
+name = "finl_unicode"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fcfdc7a0362c9f4444381a9e697c79d435fe65b52a37466fc2c1184cee9edc6"
+
+[[package]]
 name = "flagset"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1643,9 +1704,9 @@ checksum = "cdeb3aa5e95cf9aabc17f060cfa0ced7b83f042390760ca53bf09df9968acaa1"
 
 [[package]]
 name = "flate2"
-version = "1.0.28"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
+checksum = "4556222738635b7a3417ae6130d8f52201e45a0c4d1a907f0826383adb5f85e7"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1738,6 +1799,17 @@ dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
+]
+
+[[package]]
+name = "futures-intrusive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
+dependencies = [
+ "futures-core",
+ "lock_api",
+ "parking_lot 0.12.2",
 ]
 
 [[package]]
@@ -1955,12 +2027,28 @@ name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
+dependencies = [
+ "hashbrown 0.14.3",
+]
 
 [[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "heck"
@@ -1985,6 +2073,15 @@ name = "hex_lit"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3011d1213f159867b13cfd6ac92d2cd5f1345762c63be3554e84092d85a50bbd"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
 
 [[package]]
 name = "hmac"
@@ -2375,6 +2472,9 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+dependencies = [
+ "spin 0.5.2",
+]
 
 [[package]]
 name = "lazycell"
@@ -2399,6 +2499,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+
+[[package]]
 name = "libredox"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2406,6 +2512,17 @@ checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.5.0",
  "libc",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf4e226dcd58b4be396f7bd3c20da8fdee2911400705297ba7d2d7cc2c30f716"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -2447,6 +2564,16 @@ name = "maybe-uninit"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if 1.0.0",
+ "digest",
+]
 
 [[package]]
 name = "memchr"
@@ -2637,6 +2764,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
+dependencies = [
+ "byteorder",
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand",
+ "smallvec 1.13.2",
+ "zeroize",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2648,6 +2792,17 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d869c01cc0c455284163fd0092f1f93835385ccab5a98a0dcc497b2f8bf055a9"
+dependencies = [
+ "autocfg",
+ "num-integer",
  "num-traits",
 ]
 
@@ -2671,6 +2826,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -2791,7 +2947,7 @@ dependencies = [
  "bip39",
  "bitcoin",
  "boilerplate",
- "brotli 5.0.0",
+ "brotli",
  "chrono",
  "ciborium",
  "clap",
@@ -2834,6 +2990,7 @@ dependencies = [
  "serde_with",
  "serde_yaml",
  "sha3",
+ "sqlx",
  "sysinfo",
  "tempfile",
  "tokio",
@@ -3055,6 +3212,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
 name = "pkcs12"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3081,6 +3249,16 @@ dependencies = [
  "pbkdf2",
  "scrypt",
  "sha2",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
  "spki",
 ]
 
@@ -3345,6 +3523,15 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
@@ -3462,6 +3649,26 @@ dependencies = [
  "spin 0.9.8",
  "untrusted 0.9.0",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e5124fcb30e76a7e79bfee683a2746db83784b86289f6251b54b7950a0dfc"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -3973,6 +4180,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4039,6 +4256,225 @@ checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
+]
+
+[[package]]
+name = "sqlformat"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce81b7bd7c4493975347ef60d8c7e8b742d4694f4c49f93e0a12ea263938176c"
+dependencies = [
+ "itertools 0.12.1",
+ "nom",
+ "unicode_categories",
+]
+
+[[package]]
+name = "sqlx"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9a2ccff1a000a5a59cd33da541d9f2fdcd9e6e8229cc200565942bff36d0aaa"
+dependencies = [
+ "sqlx-core",
+ "sqlx-macros",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+]
+
+[[package]]
+name = "sqlx-core"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24ba59a9342a3d9bab6c56c118be528b27c9b60e490080e9711a04dccac83ef6"
+dependencies = [
+ "ahash",
+ "atoi",
+ "byteorder",
+ "bytes",
+ "crc",
+ "crossbeam-queue",
+ "either",
+ "event-listener 2.5.3",
+ "futures-channel",
+ "futures-core",
+ "futures-intrusive",
+ "futures-io",
+ "futures-util",
+ "hashlink",
+ "hex",
+ "indexmap 2.2.6",
+ "log",
+ "memchr",
+ "once_cell",
+ "paste",
+ "percent-encoding",
+ "rustls 0.21.11",
+ "rustls-pemfile 1.0.4",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec 1.13.2",
+ "sqlformat",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+ "webpki-roots",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ea40e2345eb2faa9e1e5e326db8c34711317d2b5e08d0d5741619048a803127"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sqlx-core",
+ "sqlx-macros-core",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "sqlx-macros-core"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5833ef53aaa16d860e92123292f1f6a3d53c34ba8b1969f152ef1a7bb803f3c8"
+dependencies = [
+ "dotenvy",
+ "either",
+ "heck 0.4.1",
+ "hex",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "sha2",
+ "sqlx-core",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+ "syn 1.0.109",
+ "tempfile",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "sqlx-mysql"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ed31390216d20e538e447a7a9b959e06ed9fc51c37b514b46eb758016ecd418"
+dependencies = [
+ "atoi",
+ "base64 0.21.7",
+ "bitflags 2.5.0",
+ "byteorder",
+ "bytes",
+ "crc",
+ "digest",
+ "dotenvy",
+ "either",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "generic-array",
+ "hex",
+ "hkdf",
+ "hmac",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rand",
+ "rsa",
+ "serde",
+ "sha1",
+ "sha2",
+ "smallvec 1.13.2",
+ "sqlx-core",
+ "stringprep",
+ "thiserror",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-postgres"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c824eb80b894f926f89a0b9da0c7f435d27cdd35b8c655b114e58223918577e"
+dependencies = [
+ "atoi",
+ "base64 0.21.7",
+ "bitflags 2.5.0",
+ "byteorder",
+ "crc",
+ "dotenvy",
+ "etcetera",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "hex",
+ "hkdf",
+ "hmac",
+ "home",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "rand",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec 1.13.2",
+ "sqlx-core",
+ "stringprep",
+ "thiserror",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-sqlite"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b244ef0a8414da0bed4bb1910426e890b19e5e9bccc27ada6b797d05c55ae0aa"
+dependencies = [
+ "atoi",
+ "flume",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-intrusive",
+ "futures-util",
+ "libsqlite3-sys",
+ "log",
+ "percent-encoding",
+ "serde",
+ "sqlx-core",
+ "tracing",
+ "url",
+ "urlencoding",
+]
+
+[[package]]
+name = "stringprep"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb41d74e231a107a1b4ee36bd1214b11285b77768d2e3824aedafa988fd36ee6"
+dependencies = [
+ "finl_unicode",
+ "unicode-bidi",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -4424,7 +4860,19 @@ checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
  "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -4479,6 +4927,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4489,6 +4943,12 @@ name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+
+[[package]]
+name = "unicode_categories"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
 name = "unindent"
@@ -4594,6 +5054,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4685,6 +5151,16 @@ dependencies = [
  "home",
  "once_cell",
  "rustix 0.38.34",
+]
+
+[[package]]
+name = "whoami"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a44ab49fad634e88f55bf8f9bb3abd2f27d7204172a112c7c9987e01c1c94ea9"
+dependencies = [
+ "redox_syscall 0.4.1",
+ "wasite",
 ]
 
 [[package]]
@@ -4945,6 +5421,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
 dependencies = [
  "time",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.60",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2977,6 +2977,7 @@ dependencies = [
  "ordinals",
  "pretty_assertions",
  "pulldown-cmark",
+ "rand",
  "redb",
  "regex",
  "reqwest",
@@ -4180,6 +4181,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4716,6 +4726,7 @@ dependencies = [
  "mio",
  "num_cpus",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2 0.5.6",
  "tokio-macros",
  "windows-sys 0.48.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,11 +67,12 @@ sha3 = "0.10.8"
 sqlx = { version = "0.7", features = ["runtime-tokio", "tls-rustls", "postgres"] }
 sysinfo = "0.30.3"
 tempfile = "3.2.0"
-tokio = { version = "1.17.0", features = ["rt-multi-thread"] }
+tokio = { version = "1.17.0", features = ["rt-multi-thread", "signal"] }
 tokio-stream = "0.1.9"
 tokio-util = {version = "0.7.3", features = ["compat"] }
 tower-http = { version = "0.4.0", features = ["auth", "compression-br", "compression-gzip", "cors", "set-header"] }
 urlencoding = "2.1.3"
+rand = "0.8.5"
 
 [dev-dependencies]
 criterion = "0.5.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ tokio-util = {version = "0.7.3", features = ["compat"] }
 tower-http = { version = "0.4.0", features = ["auth", "compression-br", "compression-gzip", "cors", "set-header"] }
 urlencoding = "2.1.3"
 rand = "0.8.5"
+config = "0.14.0"
 
 [dev-dependencies]
 criterion = "0.5.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ serde_json = { version = "1.0.81", features = ["preserve_order"] }
 serde_with = "3.7.0"
 serde_yaml = "0.9.17"
 sha3 = "0.10.8"
+sqlx = { version = "0.7", features = [ "runtime-tokio", "tls-rustls" , "postgres" ] }
 sysinfo = "0.30.3"
 tempfile = "3.2.0"
 tokio = { version = "1.17.0", features = ["rt-multi-thread"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ serde_json = { version = "1.0.81", features = ["preserve_order"] }
 serde_with = "3.7.0"
 serde_yaml = "0.9.17"
 sha3 = "0.10.8"
-sqlx = { version = "0.7", features = [ "runtime-tokio", "tls-rustls" , "postgres" ] }
+sqlx = { version = "0.7", features = ["runtime-tokio", "tls-rustls", "postgres"] }
 sysinfo = "0.30.3"
 tempfile = "3.2.0"
 tokio = { version = "1.17.0", features = ["rt-multi-thread"] }

--- a/crates/ordinals/src/rarity.rs
+++ b/crates/ordinals/src/rarity.rs
@@ -10,6 +10,19 @@ pub enum Rarity {
   Mythic,
 }
 
+impl Rarity {
+  pub fn to_i16(&self) -> i16 {
+    match self {
+      Rarity::Common => 0,
+      Rarity::Uncommon => 1,
+      Rarity::Rare => 2,
+      Rarity::Epic => 3,
+      Rarity::Legendary => 4,
+      Rarity::Mythic => 5,
+    }
+  }
+}
+
 impl From<Rarity> for u8 {
   fn from(rarity: Rarity) -> Self {
     rarity as u8

--- a/db/config.sql
+++ b/db/config.sql
@@ -1,0 +1,16 @@
+/* Create database */
+DROP DATABASE IF EXISTS ordinals;
+
+DO $$
+BEGIN
+  IF NOT EXISTS(SELECT FROM pg_catalog.pg_roles WHERE rolname = 'backend') THEN
+    -- Create role with password and grant the appropriate permissions to that role
+CREATE ROLE backend WITH ENCRYPTED PASSWORD 'looks-backend' LOGIN;
+ALTER ROLE backend CREATEDB;
+END IF;
+END
+$$;
+
+CREATE DATABASE ordinals WITH OWNER backend;
+
+GRANT ALL PRIVILEGES ON DATABASE ordinals to backend;

--- a/db/migrations/20240431000000_ordinals/migration.sql
+++ b/db/migrations/20240431000000_ordinals/migration.sql
@@ -11,3 +11,45 @@ CREATE TABLE events
 
 CREATE INDEX idx_events_block_height ON events (block_height);
 CREATE INDEX idx_events_inscription_id ON events (inscription_id);
+
+CREATE TABLE inscription
+(
+  id                   SERIAL PRIMARY KEY,
+  genesis_id           TEXT     NOT NULL,
+  number               INTEGER  NOT NULL,
+  content_type         VARCHAR,
+  content_length       INTEGER,
+  metadata             TEXT,
+
+  genesis_block_height INTEGER  NOT NULL,
+  genesis_block_time   BIGINT   NOT NULL,
+
+  sat_number           BIGINT,
+  sat_rarity           INTEGER,
+  sat_block_height     INTEGER,
+  sat_block_time       BIGINT,
+
+  fee                  BIGINT   NOT NULL,
+  charms               SMALLINT NOT NULL,
+
+  children             TEXT,
+  parents              TEXT
+);
+
+CREATE UNIQUE INDEX idx_unique_inscription_genesis_id ON inscription (genesis_id);
+
+CREATE TABLE location
+(
+  id             SERIAL PRIMARY KEY,
+  inscription_id INTEGER REFERENCES inscription (id),
+  block_height   INTEGER NOT NULL,
+  block_time     BIGINT  NOT NULL,
+  tx_id          TEXT    NOT NULL,
+  to_address     TEXT    NOT NULL,
+  cur_output     TEXT    NOT NULL,
+  cur_offset     BIGINT  NOT NULL,
+  from_address   TEXT,
+  prev_output    TEXT,
+  prev_offset    BIGINT,
+  value          BIGINT
+);

--- a/db/migrations/20240431000000_ordinals/migration.sql
+++ b/db/migrations/20240431000000_ordinals/migration.sql
@@ -1,0 +1,23 @@
+create table inscriptions
+(
+    id                  bigserial
+        primary key,
+    genesis_id          text                                   not null, --TODO tx_id + index, should be unique
+    number              bigint                                 not null  --TODO jubilee number, uniqueness depends on indexer implementation
+        constraint inscriptions_number_unique
+            unique,
+    sat_ordinal         numeric                                not null,
+    sat_rarity          text                                   not null,
+    sat_coinbase_height bigint                                 not null,
+    mime_type           text                                   not null, --TODO not sure we need it
+    content_type        text                                   not null,
+    content_length      bigint                                 not null, --TODO not sure we need it
+    content             bytea                                  not null, --TODO should be moved to S3
+    fee                 numeric                                not null, --TODO mint fee should belong to event?
+    curse_type          text,
+    updated_at          timestamp with time zone default now() not null,
+    recursive           boolean                  default false,
+    classic_number      bigint,
+    metadata            text,                                            --TODO needs structuring, currently dump of whatever
+    parent              text                                             --genesis_id of another inscription, used to create "collections"
+);

--- a/db/migrations/20240431000000_ordinals/migration.sql
+++ b/db/migrations/20240431000000_ordinals/migration.sql
@@ -1,23 +1,13 @@
-create table inscriptions
+CREATE TABLE events
 (
-    id                  bigserial
-        primary key,
-    genesis_id          text                                   not null, --TODO tx_id + index, should be unique
-    number              bigint                                 not null  --TODO jubilee number, uniqueness depends on indexer implementation
-        constraint inscriptions_number_unique
-            unique,
-    sat_ordinal         numeric                                not null,
-    sat_rarity          text                                   not null,
-    sat_coinbase_height bigint                                 not null,
-    mime_type           text                                   not null, --TODO not sure we need it
-    content_type        text                                   not null,
-    content_length      bigint                                 not null, --TODO not sure we need it
-    content             bytea                                  not null, --TODO should be moved to S3
-    fee                 numeric                                not null, --TODO mint fee should belong to event?
-    curse_type          text,
-    updated_at          timestamp with time zone default now() not null,
-    recursive           boolean                  default false,
-    classic_number      bigint,
-    metadata            text,                                            --TODO needs structuring, currently dump of whatever
-    parent              text                                             --genesis_id of another inscription, used to create "collections"
+  id             SERIAL PRIMARY KEY,
+  type_id        SMALLINT NOT NULL, --1,InscriptionCreated;2,InscriptionTransferred
+  block_height   BIGINT   NOT NULL,
+  inscription_id TEXT     NOT NULL,
+  location       TEXT,              -- Will hold either 'location' or 'new_location' based on type
+  old_location   TEXT,              -- Only used for InscriptionTransferred
+  created_at     TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 );
+
+CREATE INDEX idx_events_block_height ON events (block_height);
+CREATE INDEX idx_events_inscription_id ON events (inscription_id);

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,40 @@
+version: '3.8'
+services:
+
+  db:
+    image: "postgres:15.3"
+    volumes:
+      - ./db/volume:/var/lib/postgresql/data
+    ports:
+      - "55432:5432"
+    environment:
+      POSTGRES_USER: backend
+      POSTGRES_PASSWORD: looks-backend
+      POSTGRES_DB: ordinals
+      POSTGRES_PORT: 5432
+
+  db-setup:
+    image: postgres:15.3
+    depends_on:
+      - db
+    command: >
+      bash -c '
+      until pg_isready -h db -U $$POSTGRES_USER; do
+        echo "Waiting for PostgreSQL to start...";
+        sleep 1;
+      done;
+      echo "Applying config.sql to set up the database...";
+      psql -h db -U $$POSTGRES_USER -d postgres -q -f /db/config.sql;
+      echo "Applying migrations...";
+      for file in /db/migrations/*/*.sql; do
+        echo "Applying $$file";
+        psql -h db -U $$POSTGRES_USER -d $$POSTGRES_DB -q -f $$file;
+      done;
+      '
+    environment:
+      PGOPTIONS: '--client-min-messages=error'
+      POSTGRES_USER: backend
+      POSTGRES_DB: ordinals
+      PGPASSWORD: looks-backend
+    volumes:
+      - "./db:/db"

--- a/rmqconfig.json
+++ b/rmqconfig.json
@@ -1,14 +1,14 @@
 {
   "queues": [
     {
-      "name": "ord-q",
+      "name": "btc-inscription-q",
       "vhost": "/",
       "durable": true,
       "auto_delete": false,
       "arguments": {}
     },
     {
-      "name": "blocks-q",
+      "name": "btc-blocks-q",
       "vhost": "/",
       "durable": true,
       "auto_delete": false,
@@ -30,7 +30,7 @@
     {
       "source": "ord-tx",
       "vhost": "/",
-      "destination": "blocks-q",
+      "destination": "btc-blocks-q",
       "destination_type": "queue",
       "routing_key": "BlockCommitted",
       "arguments": {}
@@ -38,7 +38,7 @@
     {
       "source": "ord-tx",
       "vhost": "/",
-      "destination": "ord-q",
+      "destination": "btc-inscription-q",
       "destination_type": "queue",
       "routing_key": "InscriptionCreated",
       "arguments": {}
@@ -46,7 +46,7 @@
     {
       "source": "ord-tx",
       "vhost": "/",
-      "destination": "ord-q",
+      "destination": "btc-inscription-q",
       "destination_type": "queue",
       "routing_key": "InscriptionTransferred",
       "arguments": {}

--- a/rmqconfig.json
+++ b/rmqconfig.json
@@ -6,6 +6,13 @@
       "durable": true,
       "auto_delete": false,
       "arguments": {}
+    },
+    {
+      "name": "blocks-q",
+      "vhost": "/",
+      "durable": true,
+      "auto_delete": false,
+      "arguments": {}
     }
   ],
   "exchanges": [
@@ -23,9 +30,25 @@
     {
       "source": "ord-tx",
       "vhost": "/",
+      "destination": "blocks-q",
+      "destination_type": "queue",
+      "routing_key": "BlockCommitted",
+      "arguments": {}
+    },
+    {
+      "source": "ord-tx",
+      "vhost": "/",
       "destination": "ord-q",
       "destination_type": "queue",
-      "routing_key": "",
+      "routing_key": "InscriptionCreated",
+      "arguments": {}
+    },
+    {
+      "source": "ord-tx",
+      "vhost": "/",
+      "destination": "ord-q",
+      "destination_type": "queue",
+      "routing_key": "InscriptionTransferred",
       "arguments": {}
     }
   ]

--- a/src/api.rs
+++ b/src/api.rs
@@ -76,6 +76,33 @@ pub struct Children {
   pub page: usize,
 }
 
+#[derive(Debug, Serialize, Deserialize)]
+pub struct InscriptionDetails {
+  pub id: InscriptionId,
+  pub number: i32,
+  pub owner: Option<String>,
+  pub content_type: Option<String>,
+  pub content_length: Option<usize>,
+  pub metadata: Option<Vec<u8>>,
+
+  pub genesis_block_height: u32,
+  pub genesis_block_time: i64,
+
+  pub sat_number: Option<u64>,
+  pub sat_name: Option<String>,
+  pub sat_rarity: Option<Rarity>,
+  pub sat_block_height: Option<u32>,
+  pub sat_block_time: Option<i64>,
+
+  pub satpoint: SatPoint,
+  pub value: Option<u64>,
+  pub fee: u64,
+  pub charms: u16,
+
+  pub children: Vec<InscriptionId>,
+  pub parents: Vec<InscriptionId>,
+}
+
 #[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
 pub struct Inscription {
   pub address: Option<String>,

--- a/src/event_consumer.rs
+++ b/src/event_consumer.rs
@@ -5,7 +5,7 @@ use bitcoin::secp256k1::rand::distributions::Alphanumeric;
 use chrono::Utc;
 use clap::Parser;
 use futures::StreamExt;
-use lapin::{Connection, ConnectionProperties, options::*, types::FieldTable};
+use lapin::{options::*, types::FieldTable, Connection, ConnectionProperties};
 use rand::distributions::DistString;
 use sqlx::postgres::PgPoolOptions;
 use tokio::runtime::Runtime;
@@ -58,14 +58,20 @@ impl EventConsumer {
       let shared_pool = Arc::new(pool);
       let ord_db_client = Arc::new(OrdDbClient::new(shared_pool.clone()));
 
-      let blocks_queue = self.blocks_queue.as_deref().context("rabbitmq blocks queue path must be defined")?;
+      let blocks_queue = self
+        .blocks_queue
+        .as_deref()
+        .context("rabbitmq blocks queue path must be defined")?;
       let blocks_queue_str = blocks_queue.to_string();
       let blocks_channel = channel.clone();
       let blocks_ord_db_client = Arc::clone(&ord_db_client);
       let blocks_consumer_tag = Self::generate_consumer_tag();
       let (blocks_shutdown_tx, blocks_shutdown_rx) = oneshot::channel::<()>();
 
-      let inscriptions_queue = self.inscriptions_queue.as_deref().context("rabbitmq inscriptions queue path must be defined")?;
+      let inscriptions_queue = self
+        .inscriptions_queue
+        .as_deref()
+        .context("rabbitmq inscriptions queue path must be defined")?;
       let inscriptions_queue_str = inscriptions_queue.to_string();
       let inscriptions_channel = channel.clone();
       let inscriptions_ord_db_client = Arc::clone(&ord_db_client);
@@ -73,11 +79,25 @@ impl EventConsumer {
       let (inscriptions_shutdown_tx, inscriptions_shutdown_rx) = oneshot::channel::<()>();
 
       let blocks_consumer_handle = tokio::spawn(async move {
-        EventConsumer::consume_queue(blocks_channel, blocks_queue_str, blocks_consumer_tag, blocks_ord_db_client, blocks_shutdown_rx).await
+        EventConsumer::consume_queue(
+          blocks_channel,
+          blocks_queue_str,
+          blocks_consumer_tag,
+          blocks_ord_db_client,
+          blocks_shutdown_rx,
+        )
+        .await
       });
 
       let inscriptions_consumer_handle = tokio::spawn(async move {
-        EventConsumer::consume_queue(inscriptions_channel, inscriptions_queue_str, inscriptions_consumer_tag, inscriptions_ord_db_client, inscriptions_shutdown_rx).await
+        EventConsumer::consume_queue(
+          inscriptions_channel,
+          inscriptions_queue_str,
+          inscriptions_consumer_tag,
+          inscriptions_ord_db_client,
+          inscriptions_shutdown_rx,
+        )
+        .await
       });
 
       let mut sigterm = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())?;
@@ -92,11 +112,12 @@ impl EventConsumer {
     })
   }
 
-  async fn consume_queue(channel: lapin::Channel,
-                         queue_name: String,
-                         consumer_tag: String,
-                         ord_db_client: Arc<OrdDbClient>,
-                         mut shutdown_signal: oneshot::Receiver<()>,
+  async fn consume_queue(
+    channel: lapin::Channel,
+    queue_name: String,
+    consumer_tag: String,
+    ord_db_client: Arc<OrdDbClient>,
+    mut shutdown_signal: oneshot::Receiver<()>,
   ) -> Result<(), anyhow::Error> {
     let mut consumer = channel
       .basic_consume(
@@ -113,12 +134,12 @@ impl EventConsumer {
       match result {
         Ok(delivery) => {
           tokio::select! {
-                _ = EventConsumer::handle_delivery(delivery, &ord_db_client) => {},
-                _ = &mut shutdown_signal => {
-                    log::info!("Shutdown signal received, stopping consumer.");
-                    break;
-                },
-            }
+              _ = EventConsumer::handle_delivery(delivery, &ord_db_client) => {},
+              _ = &mut shutdown_signal => {
+                  log::info!("Shutdown signal received, stopping consumer.");
+                  break;
+              },
+          }
         }
         Err(e) => {
           log::error!("Error receiving delivery: {}", e);
@@ -127,40 +148,49 @@ impl EventConsumer {
     }
 
     log::info!("Closing consumer channel {}", queue_name);
-    channel.close(200, "Closing channel due to shutdown").await?;
+    channel
+      .close(200, "Closing channel due to shutdown")
+      .await?;
 
     Ok(())
   }
 
-  async fn handle_delivery(delivery: lapin::message::Delivery,
-                           ord_db_client: &Arc<OrdDbClient>) -> Result<(), anyhow::Error> {
+  async fn handle_delivery(
+    delivery: lapin::message::Delivery,
+    ord_db_client: &Arc<OrdDbClient>,
+  ) -> Result<(), anyhow::Error> {
     let event: Result<Event, _> = serde_json::from_slice(&delivery.data);
     match event {
       Ok(event) => {
         if let Err(err) = EventConsumer::process_event(event, ord_db_client).await {
           log::error!("Failed to process event: {}", err);
-          delivery.reject(BasicRejectOptions { requeue: false }).await?;
+          delivery
+            .reject(BasicRejectOptions { requeue: false })
+            .await?;
         } else {
           delivery.ack(BasicAckOptions::default()).await?;
         }
       }
       Err(e) => {
         log::error!("Failed to deserialize event, rejecting: {}", e);
-        delivery.reject(BasicRejectOptions { requeue: false }).await?;
+        delivery
+          .reject(BasicRejectOptions { requeue: false })
+          .await?;
       }
     }
 
     Ok(())
   }
 
-  async fn process_event(event: Event, ord_db_client: &Arc<OrdDbClient>) -> Result<(), anyhow::Error> {
+  async fn process_event(
+    event: Event,
+    ord_db_client: &Arc<OrdDbClient>,
+  ) -> Result<(), anyhow::Error> {
     match &event {
       Event::BlockCommitted {
         from_height,
         to_height,
-      } => {
-        ord_db_client.sync_blocks(from_height, to_height).await?
-      }
+      } => ord_db_client.sync_blocks(from_height, to_height).await?,
       Event::InscriptionCreated {
         block_height,
         charms,
@@ -169,7 +199,9 @@ impl EventConsumer {
         parent_inscription_ids,
         sequence_number,
       } => {
-        ord_db_client.save_inscription_created(block_height, inscription_id, location).await?
+        ord_db_client
+          .save_inscription_created(block_height, inscription_id, location)
+          .await?
       }
       Event::InscriptionTransferred {
         block_height,
@@ -178,7 +210,9 @@ impl EventConsumer {
         old_location,
         sequence_number,
       } => {
-        ord_db_client.save_inscription_transferred(block_height, inscription_id, new_location, old_location).await?;
+        ord_db_client
+          .save_inscription_transferred(block_height, inscription_id, new_location, old_location)
+          .await?;
       }
       _ => {
         log::warn!("Received an unhandled event type");
@@ -190,6 +224,11 @@ impl EventConsumer {
   fn generate_consumer_tag() -> String {
     // TODO get pod name from k8s?
     let timestamp = Utc::now().format("%Y%m%d%H%M%S");
-    format!("{}-{}-{}", "lr-ord", timestamp, Alphanumeric.sample_string(&mut rand::thread_rng(), 16))
+    format!(
+      "{}-{}-{}",
+      "lr-ord",
+      timestamp,
+      Alphanumeric.sample_string(&mut rand::thread_rng(), 16)
+    )
   }
 }

--- a/src/event_consumer.rs
+++ b/src/event_consumer.rs
@@ -67,6 +67,7 @@ impl EventConsumer {
       let ord_api_client = Arc::new(ord_api_c);
 
       let ord_indexation = Arc::new(OrdIndexation::new(
+        settings,
         Arc::clone(&ord_db_client),
         Arc::clone(&ord_api_client),
       ));

--- a/src/event_consumer.rs
+++ b/src/event_consumer.rs
@@ -1,64 +1,68 @@
 use anyhow::Context;
+use clap::Parser;
 use futures::StreamExt;
 use lapin::{options::*, types::FieldTable, Connection, ConnectionProperties};
 use tokio::runtime::Runtime;
 
 use crate::settings::Settings;
+use crate::subcommand::SubcommandResult;
 
-pub struct EventConsumer {}
+#[derive(Debug, Parser, Clone)]
+pub struct EventConsumer {
+  #[arg(long, help = "RMQ queue to consume index events.")]
+  pub(crate) rabbitmq_queue: Option<String>,
+}
 
 impl EventConsumer {
-  pub fn run(settings: &Settings) -> Result<Self, anyhow::Error> {
-    let addr = settings
-      .rabbitmq_addr()
-      .context("rabbitmq amqp credentials and url must be defined")?;
+  pub fn run(self, settings: &Settings) -> SubcommandResult {
+    Runtime::new()?.block_on(async {
+      let addr = settings
+        .rabbitmq_addr()
+        .context("rabbitmq amqp credentials and url must be defined")?;
 
-    let queue = settings
-      .rabbitmq_queue()
-      .context("rabbitmq queue path must be defined")?
-      .to_owned();
+      let queue = self
+        .rabbitmq_queue
+        .context("rabbitmq queue path must be defined")?
+        .to_owned();
 
-    std::thread::spawn(move || {
-      Runtime::new().expect("runtime is setup").block_on(async {
-        let conn = Connection::connect(&addr, ConnectionProperties::default())
+      let conn = Connection::connect(&addr, ConnectionProperties::default())
+        .await
+        .expect("connects to rabbitmq ok");
+
+      let channel = conn
+        .create_channel()
+        .await
+        .expect("creates rmq connection channel");
+
+      channel
+        .confirm_select(ConfirmSelectOptions::default())
+        .await
+        .expect("enable msg confirms");
+
+      let mut consumer = channel
+        .basic_consume(
+          &queue,
+          "lr-ord", //TODO pod name
+          BasicConsumeOptions::default(),
+          FieldTable::default(),
+        )
+        .await
+        .expect("creates rmq consumer");
+
+      log::info!("Starting to consume messages from {}", queue);
+      while let Some(delivery) = consumer.next().await {
+        let delivery = delivery.expect("error in consumer");
+        log::info!(
+          "Received message: {:?}",
+          String::from_utf8_lossy(&delivery.data)
+        );
+        delivery
+          .ack(BasicAckOptions::default())
           .await
-          .expect("connects to rabbitmq ok");
+          .expect("confirms rmq msg received");
+      }
 
-        let channel = conn
-          .create_channel()
-          .await
-          .expect("creates rmq connection channel");
-
-        channel
-          .confirm_select(ConfirmSelectOptions::default())
-          .await
-          .expect("enable msg confirms");
-
-        let mut consumer = channel
-          .basic_consume(
-            &queue,
-            "lr-ord", //TODO pod name
-            BasicConsumeOptions::default(),
-            FieldTable::default(),
-          )
-          .await
-          .expect("creates rmq consumer");
-
-        log::info!("Starting to consume messages from {}", queue);
-        while let Some(delivery) = consumer.next().await {
-          let delivery = delivery.expect("error in consumer");
-          log::info!(
-            "Received message: {:?}",
-            String::from_utf8_lossy(&delivery.data)
-          );
-          delivery
-            .ack(BasicAckOptions::default())
-            .await
-            .expect("confirms rmq msg received");
-        }
-      })
-    });
-
-    Ok(EventConsumer {})
+      Ok(None)
+    })
   }
 }

--- a/src/event_consumer.rs
+++ b/src/event_consumer.rs
@@ -9,6 +9,7 @@ use lapin::{Connection, ConnectionProperties, options::*, types::FieldTable};
 use rand::distributions::DistString;
 use sqlx::postgres::PgPoolOptions;
 use tokio::runtime::Runtime;
+use tokio::sync::oneshot;
 
 use crate::index::event::Event;
 use crate::ord_db_client::OrdDbClient;
@@ -62,38 +63,41 @@ impl EventConsumer {
       let blocks_channel = channel.clone();
       let blocks_ord_db_client = Arc::clone(&ord_db_client);
       let blocks_consumer_tag = Self::generate_consumer_tag();
+      let (blocks_shutdown_tx, blocks_shutdown_rx) = oneshot::channel::<()>();
 
       let inscriptions_queue = self.inscriptions_queue.as_deref().context("rabbitmq inscriptions queue path must be defined")?;
       let inscriptions_queue_str = inscriptions_queue.to_string();
       let inscriptions_channel = channel.clone();
       let inscriptions_ord_db_client = Arc::clone(&ord_db_client);
       let inscriptions_consumer_tag = Self::generate_consumer_tag();
+      let (inscriptions_shutdown_tx, inscriptions_shutdown_rx) = oneshot::channel::<()>();
 
       let blocks_consumer_handle = tokio::spawn(async move {
-        EventConsumer::consume_queue(blocks_channel, blocks_queue_str, blocks_consumer_tag, blocks_ord_db_client).await
+        EventConsumer::consume_queue(blocks_channel, blocks_queue_str, blocks_consumer_tag, blocks_ord_db_client, blocks_shutdown_rx).await
       });
 
       let inscriptions_consumer_handle = tokio::spawn(async move {
-        EventConsumer::consume_queue(inscriptions_channel, inscriptions_queue_str, inscriptions_consumer_tag, inscriptions_ord_db_client).await
+        EventConsumer::consume_queue(inscriptions_channel, inscriptions_queue_str, inscriptions_consumer_tag, inscriptions_ord_db_client, inscriptions_shutdown_rx).await
       });
 
+      let mut sigterm = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())?;
+      sigterm.recv().await;
+      let _ = blocks_shutdown_tx.send(());
+      let _ = inscriptions_shutdown_tx.send(());
       let _ = tokio::try_join!(blocks_consumer_handle, inscriptions_consumer_handle);
 
-      // let mut sigterm = signal(SignalKind::terminate())?;
-      // tokio::select! {
-      //   _ = sigterm.recv() => {
-      //       log::info!("Signal received, shutting down.");
-      //       shared_pool.close().await;
-      //       blocks_channel.close(200, "Closing channel").await?;
-      //       inscriptions_channel.close(200, "Closing channel").await?;
-      //   },
-      // }
+      shared_pool.close().await;
 
       Ok(None)
     })
   }
 
-  async fn consume_queue(channel: lapin::Channel, queue_name: String, consumer_tag: String, ord_db_client: Arc<OrdDbClient>) -> Result<(), anyhow::Error> {
+  async fn consume_queue(channel: lapin::Channel,
+                         queue_name: String,
+                         consumer_tag: String,
+                         ord_db_client: Arc<OrdDbClient>,
+                         mut shutdown_signal: oneshot::Receiver<()>,
+  ) -> Result<(), anyhow::Error> {
     let mut consumer = channel
       .basic_consume(
         &queue_name,
@@ -105,49 +109,16 @@ impl EventConsumer {
       .expect("creates rmq consumer");
 
     log::info!("Starting to consume messages from {}", queue_name);
-    while let Some(delivery) = consumer.next().await {
-      match delivery {
+    while let Some(result) = consumer.next().await {
+      match result {
         Ok(delivery) => {
-          let event: Result<Event, _> = serde_json::from_slice(&delivery.data);
-          match event {
-            Ok(event) => {
-              match &event {
-                Event::BlockCommitted {
-                  from_height,
-                  to_height,
-                } => {
-                  ord_db_client.sync_blocks(from_height, to_height).await?
-                }
-                Event::InscriptionCreated {
-                  block_height,
-                  charms,
-                  inscription_id,
-                  location,
-                  parent_inscription_ids,
-                  sequence_number,
-                } => {
-                  ord_db_client.save_inscription_created(block_height, inscription_id, location).await?
-                }
-                Event::InscriptionTransferred {
-                  block_height,
-                  inscription_id,
-                  new_location,
-                  old_location,
-                  sequence_number,
-                } => {
-                  ord_db_client.save_inscription_transferred(block_height, inscription_id, new_location, old_location).await?;
-                }
-                _ => {
-                  log::warn!("Received an unhandled event type");
-                }
-              }
-              delivery.ack(BasicAckOptions::default()).await?;
+          tokio::select! {
+                _ = EventConsumer::handle_delivery(delivery, &ord_db_client) => {},
+                _ = &mut shutdown_signal => {
+                    log::info!("Shutdown signal received, stopping consumer.");
+                    break;
+                },
             }
-            Err(e) => {
-              log::error!("Error deserializing event: {}", e);
-              delivery.reject(BasicRejectOptions { requeue: false }).await?;
-            }
-          }
         }
         Err(e) => {
           log::error!("Error receiving delivery: {}", e);
@@ -155,6 +126,60 @@ impl EventConsumer {
       }
     }
 
+    log::info!("Closing consumer channel {}", queue_name);
+    channel.close(200, "Closing channel due to shutdown").await?;
+
+    Ok(())
+  }
+
+  async fn handle_delivery(delivery: lapin::message::Delivery,
+                           ord_db_client: &Arc<OrdDbClient>) -> Result<(), anyhow::Error> {
+    let event: Result<Event, _> = serde_json::from_slice(&delivery.data);
+    match event {
+      Ok(event) => {
+        EventConsumer::process_event(event, ord_db_client).await?;
+        delivery.ack(BasicAckOptions::default()).await?;
+      }
+      Err(e) => {
+        log::error!("Failed to deserialize event, rejecting: {}", e);
+        delivery.reject(BasicRejectOptions { requeue: false }).await?;
+      }
+    }
+
+    Ok(())
+  }
+
+  async fn process_event(event: Event, ord_db_client: &Arc<OrdDbClient>) -> Result<(), anyhow::Error> {
+    match &event {
+      Event::BlockCommitted {
+        from_height,
+        to_height,
+      } => {
+        ord_db_client.sync_blocks(from_height, to_height).await?
+      }
+      Event::InscriptionCreated {
+        block_height,
+        charms,
+        inscription_id,
+        location,
+        parent_inscription_ids,
+        sequence_number,
+      } => {
+        ord_db_client.save_inscription_created(block_height, inscription_id, location).await?
+      }
+      Event::InscriptionTransferred {
+        block_height,
+        inscription_id,
+        new_location,
+        old_location,
+        sequence_number,
+      } => {
+        ord_db_client.save_inscription_transferred(block_height, inscription_id, new_location, old_location).await?;
+      }
+      _ => {
+        log::warn!("Received an unhandled event type");
+      }
+    }
     Ok(())
   }
 

--- a/src/event_consumer.rs
+++ b/src/event_consumer.rs
@@ -13,12 +13,10 @@ impl EventConsumer {
       .rabbitmq_addr()
       .context("rabbitmq amqp credentials and url must be defined")?;
 
-    // let queue = settings
-    //   .rabbitmq_queue()
-    //   .context("rabbitmq queue path must be defined")?
-    //   .to_owned();
-
-    let queue = "ord-q";
+    let queue = settings
+      .rabbitmq_queue()
+      .context("rabbitmq queue path must be defined")?
+      .to_owned();
 
     std::thread::spawn(move || {
       Runtime::new().expect("runtime is setup").block_on(async {
@@ -38,7 +36,7 @@ impl EventConsumer {
 
         let mut consumer = channel
           .basic_consume(
-            queue,
+            &queue,
             "lr-ord", //TODO pod name
             BasicConsumeOptions::default(),
             FieldTable::default(),

--- a/src/event_consumer.rs
+++ b/src/event_consumer.rs
@@ -1,0 +1,66 @@
+use anyhow::Context;
+use futures::StreamExt;
+use lapin::{options::*, types::FieldTable, Connection, ConnectionProperties};
+use tokio::runtime::Runtime;
+
+use crate::settings::Settings;
+
+pub struct EventConsumer {}
+
+impl EventConsumer {
+  pub fn run(settings: &Settings) -> Result<Self, anyhow::Error> {
+    let addr = settings
+      .rabbitmq_addr()
+      .context("rabbitmq amqp credentials and url must be defined")?;
+
+    // let queue = settings
+    //   .rabbitmq_queue()
+    //   .context("rabbitmq queue path must be defined")?
+    //   .to_owned();
+
+    let queue = "ord-q";
+
+    std::thread::spawn(move || {
+      Runtime::new().expect("runtime is setup").block_on(async {
+        let conn = Connection::connect(&addr, ConnectionProperties::default())
+          .await
+          .expect("connects to rabbitmq ok");
+
+        let channel = conn
+          .create_channel()
+          .await
+          .expect("creates rmq connection channel");
+
+        channel
+          .confirm_select(ConfirmSelectOptions::default())
+          .await
+          .expect("enable msg confirms");
+
+        let mut consumer = channel
+          .basic_consume(
+            queue,
+            "lr-ord", //TODO pod name
+            BasicConsumeOptions::default(),
+            FieldTable::default(),
+          )
+          .await
+          .expect("creates rmq consumer");
+
+        log::info!("Starting to consume messages from {}", queue);
+        while let Some(delivery) = consumer.next().await {
+          let delivery = delivery.expect("error in consumer");
+          log::info!(
+            "Received message: {:?}",
+            String::from_utf8_lossy(&delivery.data)
+          );
+          delivery
+            .ack(BasicAckOptions::default())
+            .await
+            .expect("confirms rmq msg received");
+        }
+      })
+    });
+
+    Ok(EventConsumer {})
+  }
+}

--- a/src/event_consumer.rs
+++ b/src/event_consumer.rs
@@ -102,9 +102,10 @@ impl EventConsumer {
             Ok(event) => {
               match &event {
                 Event::BlockCommitted {
-                  block_height,
+                  from_height,
+                  to_height,
                 } => {
-                  ord_db_client.sync_blocks(block_height).await?
+                  ord_db_client.sync_blocks(from_height, to_height).await?
                 }
                 Event::InscriptionCreated {
                   block_height,

--- a/src/event_consumer.rs
+++ b/src/event_consumer.rs
@@ -1,17 +1,17 @@
 use anyhow::Context;
 use clap::Parser;
 use futures::StreamExt;
-use lapin::{Connection, ConnectionProperties, options::*, types::FieldTable};
+use lapin::{options::*, types::FieldTable, Connection, ConnectionProperties};
 use tokio::runtime::Runtime;
 
 use ordinals::SatPoint;
 
 use crate::index::event::Event;
-use crate::InscriptionId;
 use crate::ord_api_client::OrdApiClient;
 use crate::ord_db_client::OrdDbClient;
 use crate::settings::Settings;
 use crate::subcommand::SubcommandResult;
+use crate::InscriptionId;
 
 #[derive(Debug, Parser, Clone)]
 pub struct EventConsumer {

--- a/src/event_publisher.rs
+++ b/src/event_publisher.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
+use lapin::{BasicProperties, Connection, ConnectionProperties, options::BasicPublishOptions};
 use lapin::options::ConfirmSelectOptions;
-use lapin::{options::BasicPublishOptions, BasicProperties, Connection, ConnectionProperties};
 use tokio::runtime::Runtime;
 use tokio::sync::mpsc;
 
@@ -46,7 +46,7 @@ impl EventPublisher {
           let publish = channel
             .basic_publish(
               &exchange,
-              "",
+              EventPublisher::type_name(&event),
               BasicPublishOptions::default(),
               &message,
               BasicProperties::default(),
@@ -62,5 +62,17 @@ impl EventPublisher {
     });
 
     Ok(EventPublisher { sender: tx })
+  }
+
+  fn type_name(event: &Event) -> &'static str {
+    match event {
+      Event::InscriptionCreated { .. } => "InscriptionCreated",
+      Event::InscriptionTransferred { .. } => "InscriptionTransferred",
+      Event::RuneBurned { .. } => "RuneBurned",
+      Event::RuneEtched { .. } => "RuneEtched",
+      Event::RuneMinted { .. } => "RuneMinted",
+      Event::RuneTransferred { .. } => "RuneTransferred",
+      Event::BlockCommitted { .. } => "BlockCommitted",
+    }
   }
 }

--- a/src/event_publisher.rs
+++ b/src/event_publisher.rs
@@ -41,6 +41,9 @@ impl EventPublisher {
           .expect("enable msg confirms");
 
         while let Some(event) = rx.recv().await {
+          // TODO we might want to panic if rmq is down so we don't miss any messages
+          //  if we miss messages only way to replay them is run `ord` instance from scratch
+          //  maybe we can trigger fake reorg to force it to reindex from savepoint?
           let message = serde_json::to_vec(&event).expect("failed to serialize event");
 
           let publish = channel

--- a/src/event_publisher.rs
+++ b/src/event_publisher.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
-use lapin::{BasicProperties, Connection, ConnectionProperties, options::BasicPublishOptions};
 use lapin::options::ConfirmSelectOptions;
+use lapin::{options::BasicPublishOptions, BasicProperties, Connection, ConnectionProperties};
 use tokio::runtime::Runtime;
 use tokio::sync::mpsc;
 

--- a/src/index/event.rs
+++ b/src/index/event.rs
@@ -41,4 +41,7 @@ pub enum Event {
     rune_id: RuneId,
     txid: Txid,
   },
+  BlockCommitted {
+    block_height: u32,
+  },
 }

--- a/src/index/event.rs
+++ b/src/index/event.rs
@@ -42,6 +42,7 @@ pub enum Event {
     txid: Txid,
   },
   BlockCommitted {
-    block_height: u32,
+    from_height: u32,
+    to_height: u32,
   },
 }

--- a/src/index/updater.rs
+++ b/src/index/updater.rs
@@ -1,8 +1,8 @@
 use {
   self::{inscription_updater::InscriptionUpdater, rune_updater::RuneUpdater},
-  super::{fetcher::Fetcher, *},
   futures::future::try_join_all,
   std::sync::mpsc,
+  super::{*, fetcher::Fetcher},
   tokio::sync::mpsc::{error::TryRecvError, Receiver, Sender},
 };
 
@@ -738,6 +738,12 @@ impl<'index> Updater<'index> {
     wtx.commit()?;
 
     Reorg::update_savepoints(self.index, self.height)?;
+
+    if let Some(sender) = self.index.event_sender.as_ref() {
+      sender.blocking_send(Event::BlockCommitted {
+        block_height: self.height,
+      })?;
+    }
 
     Ok(())
   }

--- a/src/index/updater.rs
+++ b/src/index/updater.rs
@@ -1,8 +1,8 @@
 use {
   self::{inscription_updater::InscriptionUpdater, rune_updater::RuneUpdater},
+  super::{fetcher::Fetcher, *},
   futures::future::try_join_all,
   std::sync::mpsc,
-  super::{*, fetcher::Fetcher},
   tokio::sync::mpsc::{error::TryRecvError, Receiver, Sender},
 };
 
@@ -696,7 +696,12 @@ impl<'index> Updater<'index> {
     Ok(())
   }
 
-  fn commit(&mut self, wtx: WriteTransaction, value_cache: HashMap<OutPoint, u64>, uncommitted: usize) -> Result {
+  fn commit(
+    &mut self,
+    wtx: WriteTransaction,
+    value_cache: HashMap<OutPoint, u64>,
+    uncommitted: usize,
+  ) -> Result {
     log::info!(
       "Committing at block height {}, {} outputs traversed, {} in map, {} cached",
       self.height,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,6 +116,7 @@ pub mod options;
 pub mod ord_api_client;
 
 pub mod ord_db_client;
+mod ord_indexation;
 pub mod outgoing;
 mod re;
 mod representation;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,6 +114,8 @@ mod macros;
 mod object;
 pub mod options;
 pub mod ord_api_client;
+
+pub mod ord_db_client;
 pub mod outgoing;
 mod re;
 mod representation;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,6 +104,7 @@ mod blocktime;
 pub mod chain;
 pub mod decimal;
 mod deserialize_from_str;
+mod event_consumer;
 mod event_publisher;
 mod fee_rate;
 pub mod index;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,6 +113,7 @@ mod into_usize;
 mod macros;
 mod object;
 pub mod options;
+pub mod ord_api_client;
 pub mod outgoing;
 mod re;
 mod representation;

--- a/src/options.rs
+++ b/src/options.rs
@@ -90,6 +90,8 @@ pub struct Options {
   pub(crate) rabbitmq_password: Option<String>,
   #[arg(long, help = "RMQ exchange to publish index events.")]
   pub(crate) rabbitmq_exchange: Option<String>,
+  #[arg(long, help = "Ord api url.")]
+  pub(crate) ord_api_url: Option<String>,
   #[arg(long, short, help = "Use regtest. Equivalent to `--chain regtest`.")]
   pub(crate) regtest: bool,
   #[arg(long, short, help = "Use signet. Equivalent to `--chain signet`.")]

--- a/src/options.rs
+++ b/src/options.rs
@@ -90,8 +90,6 @@ pub struct Options {
   pub(crate) rabbitmq_password: Option<String>,
   #[arg(long, help = "RMQ exchange to publish index events.")]
   pub(crate) rabbitmq_exchange: Option<String>,
-  #[arg(long, help = "RMQ queue to consume index events.")]
-  pub(crate) rabbitmq_queue: Option<String>,
   #[arg(long, short, help = "Use regtest. Equivalent to `--chain regtest`.")]
   pub(crate) regtest: bool,
   #[arg(long, short, help = "Use signet. Equivalent to `--chain signet`.")]

--- a/src/options.rs
+++ b/src/options.rs
@@ -90,6 +90,8 @@ pub struct Options {
   pub(crate) rabbitmq_password: Option<String>,
   #[arg(long, help = "RMQ exchange to publish index events.")]
   pub(crate) rabbitmq_exchange: Option<String>,
+  #[arg(long, help = "RMQ queue to consume index events.")]
+  pub(crate) rabbitmq_queue: Option<String>,
   #[arg(long, short, help = "Use regtest. Equivalent to `--chain regtest`.")]
   pub(crate) regtest: bool,
   #[arg(long, short, help = "Use signet. Equivalent to `--chain signet`.")]

--- a/src/options.rs
+++ b/src/options.rs
@@ -90,8 +90,6 @@ pub struct Options {
   pub(crate) rabbitmq_password: Option<String>,
   #[arg(long, help = "RMQ exchange to publish index events.")]
   pub(crate) rabbitmq_exchange: Option<String>,
-  #[arg(long, help = "Ord api url.")]
-  pub(crate) ord_api_url: Option<String>,
   #[arg(long, short, help = "Use regtest. Equivalent to `--chain regtest`.")]
   pub(crate) regtest: bool,
   #[arg(long, short, help = "Use signet. Equivalent to `--chain signet`.")]

--- a/src/ord_api_client.rs
+++ b/src/ord_api_client.rs
@@ -1,11 +1,12 @@
 use std::time::Duration;
 
 use anyhow::anyhow;
+use bitcoin::Txid;
 use http::StatusCode;
 use reqwest::{Client, RequestBuilder};
 use tokio::time::sleep;
 
-use crate::api::InscriptionDetails;
+use crate::api::{InscriptionDetails, Transaction};
 
 pub struct OrdApiClient {
   ord_api_url: String,
@@ -83,6 +84,15 @@ impl OrdApiClient {
         "{}/inscription/{}",
         self.ord_api_url, inscription_id
       ))
+      .header("Accept", "application/json");
+
+    self.execute_with_retries(request_builder, 3).await
+  }
+
+  pub async fn fetch_tx(&self, tx_id: Txid) -> Result<Transaction, anyhow::Error> {
+    let request_builder = self
+      .client
+      .get(format!("{}/tx/{}", self.ord_api_url, tx_id))
       .header("Accept", "application/json");
 
     self.execute_with_retries(request_builder, 3).await

--- a/src/ord_api_client.rs
+++ b/src/ord_api_client.rs
@@ -1,0 +1,51 @@
+use anyhow::Context;
+use reqwest::Client;
+
+use crate::api::Inscription;
+use crate::settings::Settings;
+use crate::InscriptionId;
+
+pub struct OrdApiClient {
+  ord_api_url: String,
+  client: Client,
+}
+
+impl OrdApiClient {
+  pub fn run(settings: &Settings) -> anyhow::Result<Self, anyhow::Error> {
+    let ord_api_url = settings
+      .ord_api_url()
+      .context("ord api url must be defined")?
+      .to_owned();
+
+    let client = Client::builder()
+      .timeout(std::time::Duration::from_secs(30))
+      // TODO add retries
+      // .timeout_retry_times(5)
+      // .timeout_retry_strategy(ExponentialBackoff)
+      .build()?;
+
+    Ok(OrdApiClient {
+      ord_api_url,
+      client,
+    })
+  }
+
+  pub async fn fetch_inscription_details(
+    &self,
+    inscription_id: &InscriptionId,
+  ) -> Result<Inscription, reqwest::Error> {
+    let response = self
+      .client
+      .get(format!(
+        "{}/inscription/{}",
+        self.ord_api_url, inscription_id
+      ))
+      .header("Accept", "application/json")
+      .send()
+      .await?
+      .error_for_status()?
+      .json::<Inscription>()
+      .await?;
+    Ok(response)
+  }
+}

--- a/src/ord_api_client.rs
+++ b/src/ord_api_client.rs
@@ -1,7 +1,11 @@
-use reqwest::Client;
+use std::time::Duration;
 
-use crate::api::Inscription;
-use crate::InscriptionId;
+use anyhow::anyhow;
+use http::StatusCode;
+use reqwest::{Client, RequestBuilder};
+use tokio::time::sleep;
+
+use crate::api::InscriptionDetails;
 
 pub struct OrdApiClient {
   ord_api_url: String,
@@ -9,12 +13,9 @@ pub struct OrdApiClient {
 }
 
 impl OrdApiClient {
-  pub fn run(ord_api_url: String) -> anyhow::Result<Self, anyhow::Error> {
+  pub fn new(ord_api_url: String) -> anyhow::Result<Self, anyhow::Error> {
     let client = Client::builder()
       .timeout(std::time::Duration::from_secs(30))
-      // TODO add retries
-      // .timeout_retry_times(5)
-      // .timeout_retry_strategy(ExponentialBackoff)
       .build()?;
 
     Ok(OrdApiClient {
@@ -23,22 +24,67 @@ impl OrdApiClient {
     })
   }
 
+  async fn execute_with_retries<T>(
+    &self,
+    request_builder: RequestBuilder,
+    max_attempts: u32,
+  ) -> Result<T, anyhow::Error>
+  where
+    T: for<'de> serde::Deserialize<'de> + 'static,
+  {
+    let mut attempts = 0;
+    let mut delay = Duration::from_secs(1);
+
+    while attempts < max_attempts {
+      let mut request = request_builder
+        .try_clone()
+        .ok_or_else(|| anyhow!("Failed to clone request"))?;
+
+      let response = request.send().await;
+
+      match response {
+        Ok(resp) => match resp.error_for_status() {
+          Ok(valid_response) => {
+            return valid_response
+              .json::<T>()
+              .await
+              .map_err(anyhow::Error::from);
+          }
+          Err(e)
+            if e.status() == Some(StatusCode::TOO_MANY_REQUESTS)
+              || e
+                .status()
+                .map_or_else(|| false, |status_code| status_code.is_server_error()) =>
+          {
+            attempts += 1;
+            sleep(delay).await;
+            delay *= 2;
+          }
+          Err(e) => return Err(anyhow!(e)),
+        },
+        Err(e) => {
+          attempts += 1;
+          sleep(delay).await;
+          delay *= 2;
+        }
+      }
+    }
+
+    Err(anyhow!("Exceeded maximum retry attempts"))
+  }
+
   pub async fn fetch_inscription_details(
     &self,
-    inscription_id: &InscriptionId,
-  ) -> Result<Inscription, reqwest::Error> {
-    let response = self
+    inscription_id: String,
+  ) -> Result<InscriptionDetails, anyhow::Error> {
+    let request_builder = self
       .client
       .get(format!(
         "{}/inscription/{}",
         self.ord_api_url, inscription_id
       ))
-      .header("Accept", "application/json")
-      .send()
-      .await?
-      .error_for_status()?
-      .json::<Inscription>()
-      .await?;
-    Ok(response)
+      .header("Accept", "application/json");
+
+    self.execute_with_retries(request_builder, 3).await
   }
 }

--- a/src/ord_api_client.rs
+++ b/src/ord_api_client.rs
@@ -1,8 +1,6 @@
-use anyhow::Context;
 use reqwest::Client;
 
 use crate::api::Inscription;
-use crate::settings::Settings;
 use crate::InscriptionId;
 
 pub struct OrdApiClient {
@@ -11,12 +9,7 @@ pub struct OrdApiClient {
 }
 
 impl OrdApiClient {
-  pub fn run(settings: &Settings) -> anyhow::Result<Self, anyhow::Error> {
-    let ord_api_url = settings
-      .ord_api_url()
-      .context("ord api url must be defined")?
-      .to_owned();
-
+  pub fn run(ord_api_url: String) -> anyhow::Result<Self, anyhow::Error> {
     let client = Client::builder()
       .timeout(std::time::Duration::from_secs(30))
       // TODO add retries

--- a/src/ord_api_client.rs
+++ b/src/ord_api_client.rs
@@ -6,7 +6,7 @@ use http::StatusCode;
 use reqwest::{Client, RequestBuilder};
 use tokio::time::sleep;
 
-use crate::api::{InscriptionDetails, Transaction};
+use crate::api::{BlockInfo, InscriptionDetails, Transaction};
 
 pub struct OrdApiClient {
   ord_api_url: String,
@@ -93,6 +93,15 @@ impl OrdApiClient {
     let request_builder = self
       .client
       .get(format!("{}/tx/{}", self.ord_api_url, tx_id))
+      .header("Accept", "application/json");
+
+    self.execute_with_retries(request_builder, 3).await
+  }
+
+  pub async fn fetch_block_info(&self, block_height: u32) -> Result<BlockInfo, anyhow::Error> {
+    let request_builder = self
+      .client
+      .get(format!("{}/r/blockinfo/{}", self.ord_api_url, block_height))
       .header("Accept", "application/json");
 
     self.execute_with_retries(request_builder, 3).await

--- a/src/ord_db_client.rs
+++ b/src/ord_db_client.rs
@@ -1,0 +1,28 @@
+use sqlx::PgPool;
+
+use crate::api::Inscription;
+
+pub struct OrdDbClient {
+  pool: PgPool,
+}
+
+impl OrdDbClient {
+  pub async fn run(database_url: &str) -> anyhow::Result<Self, anyhow::Error> {
+    let pool = PgPool::connect(database_url)
+      .await
+      .expect("connects to db ok");
+
+    Ok(OrdDbClient { pool })
+  }
+
+  pub async fn save_inscription(&self, inscription: Inscription) -> Result<(), sqlx::Error> {
+    log::info!("Saving inscription detailed response: {:?}", inscription);
+    // let query = sqlx::query!(
+    //         "INSERT INTO inscriptions (genesis_id, number, sat_ordinal, sat_rarity, sat_coinbase_height, mime_type, content_type, content_length, content, fee, curse_type, classic_number, metadata, parent) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    //         ??
+    //     )
+    //   .execute(&self.pool)
+    //   .await?;
+    Ok(())
+  }
+}

--- a/src/ord_db_client.rs
+++ b/src/ord_db_client.rs
@@ -9,12 +9,19 @@ pub struct OrdDbClient {
 }
 
 impl OrdDbClient {
-  pub async fn run(database_url: &str) -> anyhow::Result<Self, anyhow::Error> {
-    let pool = PgPool::connect(database_url)
-      .await
-      .expect("connects to db ok");
+  pub async fn run(database_url: &str) -> anyhow::Result<Self> {
+    let pool = PgPool::connect(database_url).await?;
+
+    // TODO handle shutdown?
 
     Ok(OrdDbClient { pool })
+  }
+
+  pub async fn sync_blocks(&self,
+                           block_height: &u32) -> Result<(), sqlx::Error> {
+    log::info!("Block committed event {}", block_height);
+    // TODO consume all blocks from this to last consumed
+    Ok(())
   }
 
   pub async fn save_inscription_created(&self,
@@ -48,5 +55,4 @@ impl OrdDbClient {
       .await?;
     Ok(())
   }
-
 }

--- a/src/ord_db_client.rs
+++ b/src/ord_db_client.rs
@@ -17,12 +17,57 @@ impl OrdDbClient {
 
   pub async fn save_inscription(&self, inscription: Inscription) -> Result<(), sqlx::Error> {
     log::info!("Saving inscription detailed response: {:?}", inscription);
-    // let query = sqlx::query!(
-    //         "INSERT INTO inscriptions (genesis_id, number, sat_ordinal, sat_rarity, sat_coinbase_height, mime_type, content_type, content_length, content, fee, curse_type, classic_number, metadata, parent) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-    //         ??
-    //     )
-    //   .execute(&self.pool)
-    //   .await?;
+
+    let genesis_id = format!("{}i{}", inscription.id.txid, inscription.id.index);
+    let parents = inscription
+      .parents
+      .iter()
+      .map(|pid| format!("{}i{}", pid.txid, pid.index))
+      .collect::<Vec<_>>()
+      .join(",");
+
+    let sql = "
+        INSERT INTO inscriptions (
+            genesis_id,
+            number,
+            sat_ordinal,
+            sat_rarity,
+            sat_coinbase_height,
+            mime_type,
+            content_type,
+            content_length,
+            content,
+            fee,
+            curse_type,
+            classic_number,
+            metadata,
+            parent
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+    ";
+
+    sqlx::query(sql)
+      .bind(genesis_id)
+      .bind(inscription.number as i64)
+      .bind(inscription.sat.map_or(0, |s| s.0 as i64))
+      .bind("")
+      .bind(inscription.height as i64)
+      .bind(
+        inscription
+          .effective_content_type
+          .clone()
+          .unwrap_or_default(),
+      )
+      .bind(inscription.content_type.clone().unwrap_or_default())
+      .bind(inscription.content_length.map_or(0, |len| len as i64))
+      .bind(vec![] as Vec<u8>)
+      .bind(inscription.fee as i64)
+      .bind("")
+      .bind(0)
+      .bind("")
+      .bind(parents)
+      .execute(&self.pool)
+      .await?;
+
     Ok(())
   }
 }

--- a/src/ord_db_client.rs
+++ b/src/ord_db_client.rs
@@ -18,8 +18,9 @@ impl OrdDbClient {
   }
 
   pub async fn sync_blocks(&self,
-                           block_height: &u32) -> Result<(), sqlx::Error> {
-    log::info!("Block committed event {}", block_height);
+                           from_height: &u32,
+                           to_height: &u32) -> Result<(), sqlx::Error> {
+    log::info!("Blocks committed event from={from_height} (excluded), to={to_height} (included)");
     // TODO consume all blocks from this to last consumed
     Ok(())
   }

--- a/src/ord_indexation.rs
+++ b/src/ord_indexation.rs
@@ -1,0 +1,65 @@
+use std::sync::Arc;
+
+use ordinals::SatPoint;
+
+use crate::ord_api_client::OrdApiClient;
+use crate::ord_db_client::OrdDbClient;
+use crate::InscriptionId;
+
+pub struct OrdIndexation {
+  ord_db_client: Arc<OrdDbClient>,
+  ord_api_client: Arc<OrdApiClient>,
+}
+
+impl OrdIndexation {
+  pub fn new(ord_db_client: Arc<OrdDbClient>, ord_api_client: Arc<OrdApiClient>) -> Self {
+    Self {
+      ord_api_client,
+      ord_db_client,
+    }
+  }
+
+  pub async fn sync_blocks(&self, from_height: &u32, to_height: &u32) -> Result<(), anyhow::Error> {
+    log::info!("Blocks committed event from={from_height} (excluded), to={to_height} (included)");
+
+    for block_height in *from_height + 1..=*to_height {
+      let events = self
+        .ord_db_client
+        .fetch_events_by_block_height(block_height)
+        .await?;
+      for event in events {
+        log::info!("Event: {:?}", event);
+        // let inscription_details = self.ord_api_client.fetch_inscription_details(event.inscription_id).await?;
+      }
+    }
+
+    Ok(())
+  }
+
+  pub async fn save_inscription_created(
+    &self,
+    block_height: &u32,
+    inscription_id: &InscriptionId,
+    location: &Option<SatPoint>,
+  ) -> Result<(), anyhow::Error> {
+    self
+      .ord_db_client
+      .save_inscription_created(block_height, inscription_id, location)
+      .await?;
+    Ok(())
+  }
+
+  pub async fn save_inscription_transferred(
+    &self,
+    block_height: &u32,
+    inscription_id: &InscriptionId,
+    new_location: &SatPoint,
+    old_location: &SatPoint,
+  ) -> Result<(), anyhow::Error> {
+    self
+      .ord_db_client
+      .save_inscription_transferred(block_height, inscription_id, new_location, old_location)
+      .await?;
+    Ok(())
+  }
+}

--- a/src/ord_indexation.rs
+++ b/src/ord_indexation.rs
@@ -28,8 +28,11 @@ impl OrdIndexation {
         .fetch_events_by_block_height(block_height)
         .await?;
       for event in events {
-        log::info!("Event: {:?}", event);
-        // let inscription_details = self.ord_api_client.fetch_inscription_details(event.inscription_id).await?;
+        let inscription_details = self
+          .ord_api_client
+          .fetch_inscription_details(event.inscription_id)
+          .await?;
+        log::info!("inscription_details: {:?}", inscription_details);
       }
     }
 

--- a/src/ord_indexation.rs
+++ b/src/ord_indexation.rs
@@ -3,17 +3,24 @@ use std::sync::Arc;
 use ordinals::SatPoint;
 
 use crate::ord_api_client::OrdApiClient;
-use crate::ord_db_client::OrdDbClient;
+use crate::ord_db_client::{Event, OrdDbClient};
+use crate::settings::Settings;
 use crate::InscriptionId;
 
 pub struct OrdIndexation {
+  settings: Settings,
   ord_db_client: Arc<OrdDbClient>,
   ord_api_client: Arc<OrdApiClient>,
 }
 
 impl OrdIndexation {
-  pub fn new(ord_db_client: Arc<OrdDbClient>, ord_api_client: Arc<OrdApiClient>) -> Self {
+  pub fn new(
+    settings: &Settings,
+    ord_db_client: Arc<OrdDbClient>,
+    ord_api_client: Arc<OrdApiClient>,
+  ) -> Self {
     Self {
+      settings: settings.clone(),
       ord_api_client,
       ord_db_client,
     }
@@ -28,15 +35,105 @@ impl OrdIndexation {
         .fetch_events_by_block_height(block_height)
         .await?;
       for event in events {
-        let inscription_details = self
-          .ord_api_client
-          .fetch_inscription_details(event.inscription_id)
-          .await?;
-        log::info!("inscription_details: {:?}", inscription_details);
+        match event.type_id {
+          1 => {
+            if let Err(e) = self.process_inscription_created(&event).await {
+              log::error!(
+                "Error processing inscription creation for event {:?}: {}",
+                event,
+                e
+              );
+            }
+          }
+          2 => {
+            // TODO: Handle type 2 events
+          }
+          _ => {
+            log::warn!("Unhandled event type: {}", event.type_id);
+          }
+        }
       }
     }
 
     Ok(())
+  }
+
+  async fn process_inscription_created(&self, event: &Event) -> Result<(), anyhow::Error> {
+    let inscription_details = self
+      .ord_api_client
+      .fetch_inscription_details(event.inscription_id.clone())
+      .await?;
+    self
+      .ord_db_client
+      .save_inscription(&inscription_details)
+      .await?;
+
+    let block_time = 0; //TODO need to fetch
+
+    let mut to_location_details: Option<(String, u64)> = None;
+    if let Some(location) = &event.location {
+      to_location_details = self.process_location(location).await?;
+    }
+
+    let mut from_location_details: Option<(String, u64)> = None;
+    if let Some(location) = &event.old_location {
+      from_location_details = self.process_location(location).await?;
+    }
+
+    self
+      .ord_db_client
+      .save_location(
+        inscription_details.id.clone(),
+        event.block_height,
+        block_time,
+        event.location.as_ref().map(|loc| loc.outpoint.txid.clone()),
+        to_location_details
+          .as_ref()
+          .map(|details| details.0.clone()),
+        event.location.as_ref().map(|loc| loc.outpoint.clone()),
+        event.location.as_ref().map(|loc| loc.offset),
+        from_location_details
+          .as_ref()
+          .map(|details| details.0.clone()),
+        event.old_location.as_ref().map(|loc| loc.outpoint.clone()),
+        event.old_location.as_ref().map(|loc| loc.offset),
+        to_location_details.as_ref().map(|details| details.1),
+      )
+      .await?;
+
+    Ok(())
+  }
+
+  async fn process_location(
+    &self,
+    location: &SatPoint,
+  ) -> Result<Option<(String, u64)>, anyhow::Error> {
+    let tx_details = self
+      .ord_api_client
+      .fetch_tx(location.outpoint.txid.clone())
+      .await?;
+
+    let output = tx_details
+      .transaction
+      .output
+      .into_iter()
+      .nth(location.outpoint.vout.try_into().unwrap());
+
+    let address = output
+      .as_ref()
+      .and_then(|o| {
+        self
+          .settings
+          .chain()
+          .address_from_script(&o.script_pubkey)
+          .ok()
+      })
+      .map(|address| address.to_string());
+
+    match address {
+      Some(addr) => Ok(Some((addr, output.unwrap().value))),
+      None => Ok(None),
+    }
   }
 
   pub async fn save_inscription_created(

--- a/src/ord_indexation.rs
+++ b/src/ord_indexation.rs
@@ -1,11 +1,16 @@
+use std::io::Cursor;
 use std::sync::Arc;
+
+use ciborium::from_reader;
+use serde_json::Value;
 
 use ordinals::SatPoint;
 
+use crate::api::BlockInfo;
+use crate::InscriptionId;
 use crate::ord_api_client::OrdApiClient;
 use crate::ord_db_client::{Event, OrdDbClient};
 use crate::settings::Settings;
-use crate::InscriptionId;
 
 pub struct OrdIndexation {
   settings: Settings,
@@ -34,10 +39,11 @@ impl OrdIndexation {
         .ord_db_client
         .fetch_events_by_block_height(block_height)
         .await?;
+      let block_info = self.ord_api_client.fetch_block_info(block_height).await?;
       for event in events {
         match event.type_id {
           1 => {
-            if let Err(e) = self.process_inscription_created(&event).await {
+            if let Err(e) = self.process_inscription_created(&event, &block_info).await {
               log::error!(
                 "Error processing inscription creation for event {:?}: {}",
                 event,
@@ -46,7 +52,16 @@ impl OrdIndexation {
             }
           }
           2 => {
-            // TODO: Handle type 2 events
+            if let Err(e) = self
+              .process_inscription_transferred(&event, &block_info)
+              .await
+            {
+              log::error!(
+                "Error processing inscription transferred for event {:?}: {}",
+                event,
+                e
+              );
+            }
           }
           _ => {
             log::warn!("Unhandled event type: {}", event.type_id);
@@ -58,17 +73,87 @@ impl OrdIndexation {
     Ok(())
   }
 
-  async fn process_inscription_created(&self, event: &Event) -> Result<(), anyhow::Error> {
+  async fn process_inscription_created(
+    &self,
+    event: &Event,
+    block_info: &BlockInfo,
+  ) -> Result<(), anyhow::Error> {
     let inscription_details = self
       .ord_api_client
       .fetch_inscription_details(event.inscription_id.clone())
       .await?;
-    self
+
+    let metadata = self.try_and_extract_metadata(&inscription_details.metadata);
+
+    let inscription_id = self
       .ord_db_client
-      .save_inscription(&inscription_details)
+      .save_inscription(&inscription_details, metadata)
       .await?;
 
-    let block_time = 0; //TODO need to fetch
+    let mut to_location_details: Option<(String, u64)> = None;
+    if let Some(location) = &event.location {
+      to_location_details = self.process_location(location).await?;
+    }
+
+    self
+      .ord_db_client
+      .save_location(
+        inscription_id,
+        event.block_height,
+        block_info.timestamp,
+        event.location.as_ref().map(|loc| loc.outpoint.txid.clone()),
+        to_location_details
+          .as_ref()
+          .map(|details| details.0.clone()),
+        event.location.as_ref().map(|loc| loc.outpoint.clone()),
+        event.location.as_ref().map(|loc| loc.offset),
+        None,
+        None,
+        None,
+        to_location_details.as_ref().map(|details| details.1),
+      )
+      .await?;
+
+    Ok(())
+  }
+
+  fn try_and_extract_metadata(&self, metadata: &Option<Vec<u8>>) -> Option<String> {
+    metadata.as_ref().and_then(|bytes| {
+      let cursor = Cursor::new(bytes);
+      let result = from_reader(cursor);
+      match result {
+        Ok(value) => {
+          match &value {
+            Value::Object(_) | Value::Array(_) => {
+              serde_json::to_string(&value).ok()
+            },
+            _ => {
+              Some(hex::encode(bytes))
+            }
+          }
+        },
+        Err(_) => {
+          Some(hex::encode(bytes))
+        }
+      }
+    })
+  }
+
+  async fn process_inscription_transferred(
+    &self,
+    event: &Event,
+    block_info: &BlockInfo,
+  ) -> Result<(), anyhow::Error> {
+    let inscription_id = self
+      .ord_db_client
+      .fetch_inscription_id_by_genesis_id(event.inscription_id.clone())
+      .await?
+      .ok_or_else(|| {
+        anyhow::anyhow!(
+          "No inscription found for genesis_id: {}",
+          event.inscription_id
+        )
+      })?;
 
     let mut to_location_details: Option<(String, u64)> = None;
     if let Some(location) = &event.location {
@@ -83,9 +168,9 @@ impl OrdIndexation {
     self
       .ord_db_client
       .save_location(
-        inscription_details.id.clone(),
+        inscription_id,
         event.block_height,
-        block_time,
+        block_info.timestamp,
         event.location.as_ref().map(|loc| loc.outpoint.txid.clone()),
         to_location_details
           .as_ref()

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -589,7 +589,6 @@ impl Settings {
 
     Some(format!("amqp://{}:{}@{}", user, pass, url))
   }
-
 }
 
 #[cfg(test)]

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -31,6 +31,7 @@ pub struct Settings {
   rabbitmq_username: Option<String>,
   rabbitmq_password: Option<String>,
   rabbitmq_exchange: Option<String>,
+  rabbitmq_queue: Option<String>,
 }
 
 impl Settings {
@@ -149,6 +150,7 @@ impl Settings {
       rabbitmq_username: self.rabbitmq_username.or(source.rabbitmq_username),
       rabbitmq_password: self.rabbitmq_password.or(source.rabbitmq_password),
       rabbitmq_exchange: self.rabbitmq_exchange.or(source.rabbitmq_exchange),
+      rabbitmq_queue: self.rabbitmq_queue.or(source.rabbitmq_queue),
     }
   }
 
@@ -187,6 +189,7 @@ impl Settings {
       rabbitmq_username: options.rabbitmq_username,
       rabbitmq_password: options.rabbitmq_password,
       rabbitmq_exchange: options.rabbitmq_exchange,
+      rabbitmq_queue: options.rabbitmq_queue,
     }
   }
 
@@ -269,6 +272,7 @@ impl Settings {
       rabbitmq_username: get_string("RMQ_USERNAME"),
       rabbitmq_password: get_string("RMQ_PASSWORD"),
       rabbitmq_exchange: get_string("RMQ_EXCHANGE"),
+      rabbitmq_queue: get_string("RMQ_QUEUE"),
     })
   }
 
@@ -302,6 +306,7 @@ impl Settings {
       rabbitmq_username: None,
       rabbitmq_password: None,
       rabbitmq_exchange: None,
+      rabbitmq_queue: None,
     }
   }
 
@@ -385,6 +390,7 @@ impl Settings {
       rabbitmq_username: self.rabbitmq_username,
       rabbitmq_password: self.rabbitmq_password,
       rabbitmq_exchange: self.rabbitmq_exchange,
+      rabbitmq_queue: self.rabbitmq_queue,
     })
   }
 
@@ -580,6 +586,10 @@ impl Settings {
 
   pub fn rabbitmq_exchange(&self) -> Option<&str> {
     self.rabbitmq_exchange.as_deref()
+  }
+
+  pub fn rabbitmq_queue(&self) -> Option<&str> {
+    self.rabbitmq_queue.as_deref()
   }
 
   pub fn rabbitmq_addr(&self) -> Option<String> {
@@ -1040,6 +1050,7 @@ mod tests {
       ("RMQ_USERNAME", "rmq username"),
       ("RMQ_PASSWORD", "rmq password"),
       ("RMQ_EXCHANGE", "rmq exchange"),
+      ("RMQ_QUEUE", "rmq queue"),
     ]
     .into_iter()
     .map(|(key, value)| (key.into(), value.into()))
@@ -1087,6 +1098,7 @@ mod tests {
         rabbitmq_username: Some("rmq username".into()),
         rabbitmq_password: Some("rmq password".into()),
         rabbitmq_exchange: Some("rmq exchange".into()),
+        rabbitmq_queue: Some("rmq queue".into()),
       }
     );
   }
@@ -1123,6 +1135,7 @@ mod tests {
           "--rabbitmq-username=rmq username",
           "--rabbitmq-password=rmq password",
           "--rabbitmq-exchange=rmq exchange",
+          "--rabbitmq-queue=rmq queue",
         ])
         .unwrap()
       ),
@@ -1155,6 +1168,7 @@ mod tests {
         rabbitmq_username: Some("rmq username".into()),
         rabbitmq_password: Some("rmq password".into()),
         rabbitmq_exchange: Some("rmq exchange".into()),
+        rabbitmq_queue: Some("rmq queue".into()),
       }
     );
   }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -31,7 +31,6 @@ pub struct Settings {
   rabbitmq_username: Option<String>,
   rabbitmq_password: Option<String>,
   rabbitmq_exchange: Option<String>,
-  rabbitmq_queue: Option<String>,
 }
 
 impl Settings {
@@ -150,7 +149,6 @@ impl Settings {
       rabbitmq_username: self.rabbitmq_username.or(source.rabbitmq_username),
       rabbitmq_password: self.rabbitmq_password.or(source.rabbitmq_password),
       rabbitmq_exchange: self.rabbitmq_exchange.or(source.rabbitmq_exchange),
-      rabbitmq_queue: self.rabbitmq_queue.or(source.rabbitmq_queue),
     }
   }
 
@@ -189,7 +187,6 @@ impl Settings {
       rabbitmq_username: options.rabbitmq_username,
       rabbitmq_password: options.rabbitmq_password,
       rabbitmq_exchange: options.rabbitmq_exchange,
-      rabbitmq_queue: options.rabbitmq_queue,
     }
   }
 
@@ -272,7 +269,6 @@ impl Settings {
       rabbitmq_username: get_string("RMQ_USERNAME"),
       rabbitmq_password: get_string("RMQ_PASSWORD"),
       rabbitmq_exchange: get_string("RMQ_EXCHANGE"),
-      rabbitmq_queue: get_string("RMQ_QUEUE"),
     })
   }
 
@@ -306,7 +302,6 @@ impl Settings {
       rabbitmq_username: None,
       rabbitmq_password: None,
       rabbitmq_exchange: None,
-      rabbitmq_queue: None,
     }
   }
 
@@ -390,7 +385,6 @@ impl Settings {
       rabbitmq_username: self.rabbitmq_username,
       rabbitmq_password: self.rabbitmq_password,
       rabbitmq_exchange: self.rabbitmq_exchange,
-      rabbitmq_queue: self.rabbitmq_queue,
     })
   }
 
@@ -586,10 +580,6 @@ impl Settings {
 
   pub fn rabbitmq_exchange(&self) -> Option<&str> {
     self.rabbitmq_exchange.as_deref()
-  }
-
-  pub fn rabbitmq_queue(&self) -> Option<&str> {
-    self.rabbitmq_queue.as_deref()
   }
 
   pub fn rabbitmq_addr(&self) -> Option<String> {
@@ -1098,7 +1088,6 @@ mod tests {
         rabbitmq_username: Some("rmq username".into()),
         rabbitmq_password: Some("rmq password".into()),
         rabbitmq_exchange: Some("rmq exchange".into()),
-        rabbitmq_queue: Some("rmq queue".into()),
       }
     );
   }
@@ -1168,7 +1157,6 @@ mod tests {
         rabbitmq_username: Some("rmq username".into()),
         rabbitmq_password: Some("rmq password".into()),
         rabbitmq_exchange: Some("rmq exchange".into()),
-        rabbitmq_queue: Some("rmq queue".into()),
       }
     );
   }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1040,7 +1040,6 @@ mod tests {
       ("RMQ_USERNAME", "rmq username"),
       ("RMQ_PASSWORD", "rmq password"),
       ("RMQ_EXCHANGE", "rmq exchange"),
-      ("RMQ_QUEUE", "rmq queue"),
     ]
     .into_iter()
     .map(|(key, value)| (key.into(), value.into()))
@@ -1124,7 +1123,6 @@ mod tests {
           "--rabbitmq-username=rmq username",
           "--rabbitmq-password=rmq password",
           "--rabbitmq-exchange=rmq exchange",
-          "--rabbitmq-queue=rmq queue",
         ])
         .unwrap()
       ),

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -31,6 +31,7 @@ pub struct Settings {
   rabbitmq_username: Option<String>,
   rabbitmq_password: Option<String>,
   rabbitmq_exchange: Option<String>,
+  ord_api_url: Option<String>,
 }
 
 impl Settings {
@@ -149,6 +150,7 @@ impl Settings {
       rabbitmq_username: self.rabbitmq_username.or(source.rabbitmq_username),
       rabbitmq_password: self.rabbitmq_password.or(source.rabbitmq_password),
       rabbitmq_exchange: self.rabbitmq_exchange.or(source.rabbitmq_exchange),
+      ord_api_url: self.ord_api_url.or(source.ord_api_url),
     }
   }
 
@@ -187,6 +189,7 @@ impl Settings {
       rabbitmq_username: options.rabbitmq_username,
       rabbitmq_password: options.rabbitmq_password,
       rabbitmq_exchange: options.rabbitmq_exchange,
+      ord_api_url: options.ord_api_url,
     }
   }
 
@@ -269,6 +272,7 @@ impl Settings {
       rabbitmq_username: get_string("RMQ_USERNAME"),
       rabbitmq_password: get_string("RMQ_PASSWORD"),
       rabbitmq_exchange: get_string("RMQ_EXCHANGE"),
+      ord_api_url: get_string("ORD_API_URL"),
     })
   }
 
@@ -302,6 +306,7 @@ impl Settings {
       rabbitmq_username: None,
       rabbitmq_password: None,
       rabbitmq_exchange: None,
+      ord_api_url: None,
     }
   }
 
@@ -385,6 +390,7 @@ impl Settings {
       rabbitmq_username: self.rabbitmq_username,
       rabbitmq_password: self.rabbitmq_password,
       rabbitmq_exchange: self.rabbitmq_exchange,
+      ord_api_url: self.ord_api_url,
     })
   }
 
@@ -444,7 +450,7 @@ impl Settings {
             "regtest" => Chain::Regtest,
             "signet" => Chain::Signet,
             other => bail!("Bitcoin RPC server on unknown chain: {other}"),
-          }
+          };
         }
         Err(bitcoincore_rpc::Error::JsonRpc(bitcoincore_rpc::jsonrpc::Error::Rpc(err)))
           if err.code == -28 => {}
@@ -588,6 +594,10 @@ impl Settings {
     let url = self.rabbitmq_url.as_ref()?;
 
     Some(format!("amqp://{}:{}@{}", user, pass, url))
+  }
+
+  pub fn ord_api_url(&self) -> Option<&str> {
+    self.ord_api_url.as_deref()
   }
 }
 
@@ -1040,10 +1050,11 @@ mod tests {
       ("RMQ_USERNAME", "rmq username"),
       ("RMQ_PASSWORD", "rmq password"),
       ("RMQ_EXCHANGE", "rmq exchange"),
+      ("ORD_API_URL", "http://127.0.0.1:8080"),
     ]
-    .into_iter()
-    .map(|(key, value)| (key.into(), value.into()))
-    .collect::<BTreeMap<String, String>>();
+      .into_iter()
+      .map(|(key, value)| (key.into(), value.into()))
+      .collect::<BTreeMap<String, String>>();
 
     pretty_assert_eq!(
       Settings::from_env(env).unwrap(),
@@ -1087,6 +1098,7 @@ mod tests {
         rabbitmq_username: Some("rmq username".into()),
         rabbitmq_password: Some("rmq password".into()),
         rabbitmq_exchange: Some("rmq exchange".into()),
+        ord_api_url: Some("http://127.0.0.1:8080".into()),
       }
     );
   }
@@ -1123,6 +1135,7 @@ mod tests {
           "--rabbitmq-username=rmq username",
           "--rabbitmq-password=rmq password",
           "--rabbitmq-exchange=rmq exchange",
+          "--ord-api-url=http://127.0.0.1:8080",
         ])
         .unwrap()
       ),
@@ -1155,6 +1168,7 @@ mod tests {
         rabbitmq_username: Some("rmq username".into()),
         rabbitmq_password: Some("rmq password".into()),
         rabbitmq_exchange: Some("rmq exchange".into()),
+        ord_api_url: Some("http://127.0.0.1:8080".into()),
       }
     );
   }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -31,7 +31,6 @@ pub struct Settings {
   rabbitmq_username: Option<String>,
   rabbitmq_password: Option<String>,
   rabbitmq_exchange: Option<String>,
-  ord_api_url: Option<String>,
 }
 
 impl Settings {
@@ -150,7 +149,6 @@ impl Settings {
       rabbitmq_username: self.rabbitmq_username.or(source.rabbitmq_username),
       rabbitmq_password: self.rabbitmq_password.or(source.rabbitmq_password),
       rabbitmq_exchange: self.rabbitmq_exchange.or(source.rabbitmq_exchange),
-      ord_api_url: self.ord_api_url.or(source.ord_api_url),
     }
   }
 
@@ -189,7 +187,6 @@ impl Settings {
       rabbitmq_username: options.rabbitmq_username,
       rabbitmq_password: options.rabbitmq_password,
       rabbitmq_exchange: options.rabbitmq_exchange,
-      ord_api_url: options.ord_api_url,
     }
   }
 
@@ -272,7 +269,6 @@ impl Settings {
       rabbitmq_username: get_string("RMQ_USERNAME"),
       rabbitmq_password: get_string("RMQ_PASSWORD"),
       rabbitmq_exchange: get_string("RMQ_EXCHANGE"),
-      ord_api_url: get_string("ORD_API_URL"),
     })
   }
 
@@ -306,7 +302,6 @@ impl Settings {
       rabbitmq_username: None,
       rabbitmq_password: None,
       rabbitmq_exchange: None,
-      ord_api_url: None,
     }
   }
 
@@ -390,7 +385,6 @@ impl Settings {
       rabbitmq_username: self.rabbitmq_username,
       rabbitmq_password: self.rabbitmq_password,
       rabbitmq_exchange: self.rabbitmq_exchange,
-      ord_api_url: self.ord_api_url,
     })
   }
 
@@ -596,9 +590,6 @@ impl Settings {
     Some(format!("amqp://{}:{}@{}", user, pass, url))
   }
 
-  pub fn ord_api_url(&self) -> Option<&str> {
-    self.ord_api_url.as_deref()
-  }
 }
 
 #[cfg(test)]
@@ -1050,7 +1041,6 @@ mod tests {
       ("RMQ_USERNAME", "rmq username"),
       ("RMQ_PASSWORD", "rmq password"),
       ("RMQ_EXCHANGE", "rmq exchange"),
-      ("ORD_API_URL", "http://127.0.0.1:8080"),
     ]
       .into_iter()
       .map(|(key, value)| (key.into(), value.into()))
@@ -1098,7 +1088,6 @@ mod tests {
         rabbitmq_username: Some("rmq username".into()),
         rabbitmq_password: Some("rmq password".into()),
         rabbitmq_exchange: Some("rmq exchange".into()),
-        ord_api_url: Some("http://127.0.0.1:8080".into()),
       }
     );
   }
@@ -1135,7 +1124,6 @@ mod tests {
           "--rabbitmq-username=rmq username",
           "--rabbitmq-password=rmq password",
           "--rabbitmq-exchange=rmq exchange",
-          "--ord-api-url=http://127.0.0.1:8080",
         ])
         .unwrap()
       ),
@@ -1168,7 +1156,6 @@ mod tests {
         rabbitmq_username: Some("rmq username".into()),
         rabbitmq_password: Some("rmq password".into()),
         rabbitmq_exchange: Some("rmq exchange".into()),
-        ord_api_url: Some("http://127.0.0.1:8080".into()),
       }
     );
   }

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -1,5 +1,6 @@
 use crate::event_publisher::EventPublisher;
 use crate::ord_api_client::OrdApiClient;
+use crate::ord_db_client::OrdDbClient;
 
 use super::*;
 
@@ -90,8 +91,7 @@ impl Subcommand {
         server.run(settings, index, handle)
       }
       Self::EventConsumer(event_consumer) => {
-        let ord_api_client = OrdApiClient::run(&settings)?;
-        event_consumer.run(&settings, ord_api_client)
+        event_consumer.run(&settings)
       }
       Self::Settings => settings::run(settings),
       Self::Subsidy(subsidy) => subsidy.run(),

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -77,7 +77,7 @@ impl Subcommand {
         server.run(settings, index, handle)
       }
       Self::EventServer(server) => {
-        let consumer = EventConsumer::run(&settings)?;
+        let _consumer = EventConsumer::run(&settings)?;
         let publisher = EventPublisher::run(&settings)?;
         let handle = axum_server::Handle::new();
         let index = Arc::new(Index::open_with_event_sender(

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -90,9 +90,7 @@ impl Subcommand {
         LISTENERS.lock().unwrap().push(handle.clone());
         server.run(settings, index, handle)
       }
-      Self::EventConsumer(event_consumer) => {
-        event_consumer.run(&settings)
-      }
+      Self::EventConsumer(event_consumer) => event_consumer.run(&settings),
       Self::Settings => settings::run(settings),
       Self::Subsidy(subsidy) => subsidy.run(),
       Self::Supply => supply::run(),

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -1,4 +1,3 @@
-use crate::event_consumer::EventConsumer;
 use crate::event_publisher::EventPublisher;
 
 use super::*;
@@ -44,6 +43,8 @@ pub(crate) enum Subcommand {
   Server(server::Server),
   #[command(about = "Run the explorer server in event emit mode")]
   EventServer(server::Server),
+  #[command(about = "Run the index event consumer")]
+  EventConsumer(event_consumer::EventConsumer),
   #[command(about = "Display settings")]
   Settings,
   #[command(about = "Display information about a block's subsidy")]
@@ -77,7 +78,6 @@ impl Subcommand {
         server.run(settings, index, handle)
       }
       Self::EventServer(server) => {
-        let _consumer = EventConsumer::run(&settings)?;
         let publisher = EventPublisher::run(&settings)?;
         let handle = axum_server::Handle::new();
         let index = Arc::new(Index::open_with_event_sender(
@@ -88,6 +88,7 @@ impl Subcommand {
         LISTENERS.lock().unwrap().push(handle.clone());
         server.run(settings, index, handle)
       }
+      Self::EventConsumer(event_consumer) => event_consumer.run(&settings),
       Self::Settings => settings::run(settings),
       Self::Subsidy(subsidy) => subsidy.run(),
       Self::Supply => supply::run(),

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -1,3 +1,4 @@
+use crate::event_consumer::EventConsumer;
 use crate::event_publisher::EventPublisher;
 
 use super::*;
@@ -76,6 +77,7 @@ impl Subcommand {
         server.run(settings, index, handle)
       }
       Self::EventServer(server) => {
+        let consumer = EventConsumer::run(&settings)?;
         let publisher = EventPublisher::run(&settings)?;
         let handle = axum_server::Handle::new();
         let index = Arc::new(Index::open_with_event_sender(

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -1,4 +1,5 @@
 use crate::event_publisher::EventPublisher;
+use crate::ord_api_client::OrdApiClient;
 
 use super::*;
 
@@ -89,9 +90,9 @@ impl Subcommand {
         server.run(settings, index, handle)
       }
       Self::EventConsumer(event_consumer) => {
-        let index = Arc::new(Index::open(&settings)?);
-        event_consumer.run(&settings, index)
-      },
+        let ord_api_client = OrdApiClient::run(&settings)?;
+        event_consumer.run(&settings, ord_api_client)
+      }
       Self::Settings => settings::run(settings),
       Self::Subsidy(subsidy) => subsidy.run(),
       Self::Supply => supply::run(),

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -88,7 +88,10 @@ impl Subcommand {
         LISTENERS.lock().unwrap().push(handle.clone());
         server.run(settings, index, handle)
       }
-      Self::EventConsumer(event_consumer) => event_consumer.run(&settings),
+      Self::EventConsumer(event_consumer) => {
+        let index = Arc::new(Index::open(&settings)?);
+        event_consumer.run(&settings, index)
+      },
       Self::Settings => settings::run(settings),
       Self::Subsidy(subsidy) => subsidy.run(),
       Self::Supply => supply::run(),

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -1520,6 +1520,7 @@ impl Server {
     })
   }
 
+  // TODO need to enhance this api to return all necessary data
   async fn inscription(
     Extension(server_config): Extension<Arc<ServerConfig>>,
     Extension(index): Extension<Arc<Index>>,


### PR DESCRIPTION
```
Main flow
    we run multiple ord instances with full index --index-sats
    ord emits events to rmq (blocks-q, ord-q)
    we run event-consumer to consume rmq queues
        ord-q
            persists raw events (inscription creation, inscription transfer)
        blocks-q
            fetch all raw events for message blocks, sort by block_height, type (inserts first)
                for each event
                    fetch inscription details from ord api and write to postgres
                    fetch location details from ord api and write to postgres

Reindex flow (ord dies)
    ord instance restarts and recovers
    ord emits events to rmq (blocks-q, ord-q)
    event-consumer follows main flow (commit events have block range)

Reindex flow (we die)
    manually publish rmq message with block range via rmq admin
```

https://github.com/LooksRare/helm/pull/1995