### PR TITLE
Add retries for rmq publish

### DIFF
--- a/rmqconfig.json
+++ b/rmqconfig.json
@@ -5,14 +5,18 @@
       "vhost": "/",
       "durable": true,
       "auto_delete": false,
-      "arguments": {}
+      "arguments": {
+        "x-queue-type": "quorum"
+      }
     },
     {
       "name": "btc-blocks-q",
       "vhost": "/",
       "durable": true,
       "auto_delete": false,
-      "arguments": {}
+      "arguments": {
+        "x-queue-type": "quorum"
+      }
     }
   ],
   "exchanges": [

--- a/src/indexer/block_consumer.rs
+++ b/src/indexer/block_consumer.rs
@@ -62,7 +62,7 @@ impl BlockConsumer {
     })
   }
 
-  /// Handle the persistence of incoming queue "event" messages.
+  /// Handle the persistence of incoming queue "block" messages.
   ///
   /// Re-enqueues the message up to `max_delivery` times for processing failures.
   /// Bubbles up the `lapin::Error` only if the ack/nack/reject itself fails.

--- a/src/indexer/block_consumer.rs
+++ b/src/indexer/block_consumer.rs
@@ -91,7 +91,7 @@ impl BlockConsumer {
     let event = serde_json::from_slice::<Event>(&delivery.data).context("should deserialize evt");
 
     if let Ok(ref e) = event {
-      if let Ok(_) = BlockConsumer::process_event(e, indexer).await {
+      if BlockConsumer::process_event(e, indexer).await.is_ok() {
         delivery.ack(BasicAckOptions::default()).await?
       };
     };

--- a/src/indexer/event_consumer.rs
+++ b/src/indexer/event_consumer.rs
@@ -77,7 +77,7 @@ impl EventConsumer {
     let event = serde_json::from_slice::<Event>(&delivery.data).context("should deserialize evt");
 
     if let Ok(ref e) = event {
-      if let Ok(_) = EventConsumer::process_event(e, db).await {
+      if EventConsumer::process_event(e, db).await.is_ok() {
         delivery.ack(BasicAckOptions::default()).await?
       };
     };

--- a/src/indexer/event_publisher.rs
+++ b/src/indexer/event_publisher.rs
@@ -82,7 +82,7 @@ impl EventPublisher {
             channel = setup_rabbitmq_connection(&addr)
               .await
               .inspect_err(|e| log::error!("error reconnecting rmq: {e}"))
-              .unwrap_or_else(|_| channel);
+              .unwrap_or(channel);
 
             backoff_delay *= 2;
           }

--- a/src/indexer/event_publisher.rs
+++ b/src/indexer/event_publisher.rs
@@ -64,7 +64,12 @@ impl EventPublisher {
           log::error!("Error publishing message: {}. Attempting to recreate the RMQ channel. Retries left: {}. Retrying in {} seconds.", e, attempts, backoff_delay.as_secs());
           sleep(backoff_delay).await;
           backoff_delay *= 2;
-          channel = setup_rabbitmq_connection(&addr).await?;
+          channel = setup_rabbitmq_connection(&addr)
+            .await
+            .unwrap_or_else(|conn_err| {
+              log::error!("Failed to recreate RabbitMQ channel: {}", conn_err);
+              channel
+            });
         } else {
           break;
         }

--- a/src/indexer/event_publisher.rs
+++ b/src/indexer/event_publisher.rs
@@ -54,7 +54,7 @@ impl EventPublisher {
       let message = serde_json::to_vec(&event)?;
       let routing_key = EventPublisher::type_name(&event);
 
-      let mut attempts = 3;
+      let mut attempts = 10;
       let mut backoff_delay = Duration::from_secs(1);
       while attempts > 0 {
         let result =

--- a/src/indexer/rmq_con.rs
+++ b/src/indexer/rmq_con.rs
@@ -1,5 +1,3 @@
-use std::time::Duration;
-
 use anyhow::{Context, Error};
 use chrono::Utc;
 use lapin::options::ConfirmSelectOptions;
@@ -7,38 +5,8 @@ use lapin::tcp::{AMQPUriTcpExt, NativeTlsConnector};
 use lapin::uri::AMQPUri;
 use lapin::{Connection, ConnectionProperties};
 use rand::distributions::{Alphanumeric, DistString};
-use tokio::time::sleep;
 
 pub async fn setup_rabbitmq_connection(addr: &str) -> Result<lapin::Channel, anyhow::Error> {
-  let mut attempts = 10;
-  let mut backoff_delay = Duration::from_secs(1);
-  while attempts > 0 {
-    match create_channel(addr).await {
-      Ok(channel) => return Ok(channel),
-      Err(e) => {
-        attempts -= 1;
-        if attempts < 0 {
-          return Err(e);
-        } else {
-          log::error!(
-            "Error creating RabbitMQ channel: {}. Retries left: {}. Retrying in {} seconds.",
-            e,
-            attempts,
-            backoff_delay.as_secs()
-          );
-          sleep(backoff_delay).await;
-          backoff_delay *= 2;
-        }
-      }
-    }
-  }
-  Err(anyhow::Error::new(std::io::Error::new(
-    std::io::ErrorKind::Other,
-    "Failed to establish RabbitMQ channel after retries",
-  )))
-}
-
-async fn create_channel(addr: &str) -> Result<lapin::Channel, anyhow::Error> {
   let conn = connect_to_rabbitmq(addr).await?;
   let channel = conn
     .create_channel()

--- a/src/indexer/rmq_con.rs
+++ b/src/indexer/rmq_con.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use anyhow::{Context, Error};
 use chrono::Utc;
 use lapin::options::ConfirmSelectOptions;
@@ -5,8 +7,38 @@ use lapin::tcp::{AMQPUriTcpExt, NativeTlsConnector};
 use lapin::uri::AMQPUri;
 use lapin::{Connection, ConnectionProperties};
 use rand::distributions::{Alphanumeric, DistString};
+use tokio::time::sleep;
 
 pub async fn setup_rabbitmq_connection(addr: &str) -> Result<lapin::Channel, anyhow::Error> {
+  let mut attempts = 10;
+  let mut backoff_delay = Duration::from_secs(1);
+  while attempts > 0 {
+    match create_channel(addr).await {
+      Ok(channel) => return Ok(channel),
+      Err(e) => {
+        attempts -= 1;
+        if attempts < 0 {
+          return Err(e);
+        } else {
+          log::error!(
+            "Error creating RabbitMQ channel: {}. Retries left: {}. Retrying in {} seconds.",
+            e,
+            attempts,
+            backoff_delay.as_secs()
+          );
+          sleep(backoff_delay).await;
+          backoff_delay *= 2;
+        }
+      }
+    }
+  }
+  Err(anyhow::Error::new(std::io::Error::new(
+    std::io::ErrorKind::Other,
+    "Failed to establish RabbitMQ channel after retries",
+  )))
+}
+
+async fn create_channel(addr: &str) -> Result<lapin::Channel, anyhow::Error> {
   let conn = connect_to_rabbitmq(addr).await?;
   let channel = conn
     .create_channel()


### PR DESCRIPTION
Publishing
    * graceful restart - ok as is. Commit finishes when last event gets published.
    * kill - ok as is. Causes `ord` to revert to previous savepoint which takes a long time to repair when starting up, but once it's up it re-emits the blocks that were not committed so not event loss.
    * rmq failed ack - we retry to create a new connection, if not successful we gracefully shutdown the app and have event loss.
    * rmq connection killed - we retry to create a new connection, if not successful we gracefully shutdown the app and have event loss.
    * rmq down - we retry to create a new connection, if not successful we gracefully shutdown the app and have event loss.

This should cover most of the cases where we have infra issues.

Reindexing from scratch on the light version takes ~8 hours so we want to avoid it and worst case when rmq goes down we need to spin up a new instance and reindex til the failure.

Consumers
* graceful restart - ok as is, event goes back to the queue.
* kill - ok as is, event goes back to the queue.
* processing error - we requeue 3x and reject the message after.
